### PR TITLE
fixed compiling issue for when x11 is not included as a feature

### DIFF
--- a/src/overlays/screen.rs
+++ b/src/overlays/screen.rs
@@ -735,7 +735,7 @@ pub fn create_screens_wayland(
 }
 
 #[cfg(not(feature = "x11"))]
-pub fn create_screens_x11(session: &AppSession) -> anyhow::Result<ScreenCreateData> {
+pub fn create_screens_x11(_app: &mut AppState) -> anyhow::Result<ScreenCreateData> {
     anyhow::bail!("X11 support not enabled")
 }
 


### PR DESCRIPTION
Noticed that a compiler error appeared when compiling without x11 as a feature. With some investigation I discovered that the non x11 create_screens_x11 function was not modified along side the x11 create_screens_x11 function causing the error to occur. 