### PR TITLE
fix: loading pipewire tokens

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -179,9 +179,6 @@ pub struct GeneralConfig {
     #[serde(default = "def_one")]
     pub long_press_duration: f32,
 
-    #[serde(default = "def_pw_tokens")]
-    pub pw_tokens: PwTokenMap,
-
     #[serde(default = "def_osc_port")]
     pub osc_out_port: u16,
 

--- a/src/overlays/screen.rs
+++ b/src/overlays/screen.rs
@@ -632,8 +632,9 @@ fn get_pw_token_path() -> PathBuf {
 }
 
 #[cfg(feature = "wayland")]
-pub fn save_pw_token_config(tokens: &PwTokenMap) -> Result<(), Box<dyn Error>> {
-    let yaml = serde_yaml::to_string(tokens)?;
+pub fn save_pw_token_config(tokens: PwTokenMap) -> Result<(), Box<dyn Error>> {
+    let conf = TokenConf { pw_tokens: tokens };
+    let yaml = serde_yaml::to_string(&conf)?;
     std::fs::write(get_pw_token_path(), yaml)?;
 
     Ok(())
@@ -721,7 +722,7 @@ pub fn create_screens_wayland(
 
     if pw_tokens_copy != pw_tokens {
         // Token list changed, re-create token config file
-        if let Err(err) = save_pw_token_config(&pw_tokens) {
+        if let Err(err) = save_pw_token_config(pw_tokens) {
             log::error!("Failed to save Pipewire token config: {}", err);
         }
     }


### PR DESCRIPTION
ignore pw_tokens.yaml when loading files from conf.d, and fix load_pw_token_config