### PR TITLE
Add bindings for WMR controllers

### DIFF
--- a/src/backend/openxr/helpers.rs
+++ b/src/backend/openxr/helpers.rs
@@ -26,6 +26,11 @@ pub(super) fn init_xr() -> Result<(xr::Instance, xr::SystemId), anyhow::Error> {
         enabled_extensions.ext_dpad_binding = true;
     } else {
         log::warn!("Missing EXT_dpad_binding extension.");
+    }    
+    if available_extensions.ext_hp_mixed_reality_controller {
+        enabled_extensions.ext_hp_mixed_reality_controller = true;
+    } else {
+        log::warn!("Missing EXT_hp_mixed_reality_controller extension.");
     }
 
     //#[cfg(not(debug_assertions))]

--- a/src/backend/openxr/helpers.rs
+++ b/src/backend/openxr/helpers.rs
@@ -21,6 +21,12 @@ pub(super) fn init_xr() -> Result<(xr::Instance, xr::SystemId), anyhow::Error> {
     let mut enabled_extensions = xr::ExtensionSet::default();
     enabled_extensions.khr_vulkan_enable2 = true;
     enabled_extensions.extx_overlay = true;
+    if available_extensions.khr_binding_modification && available_extensions.ext_dpad_binding {
+        enabled_extensions.khr_binding_modification = true;
+        enabled_extensions.ext_dpad_binding = true;
+    } else {
+        log::warn!("Missing EXT_dpad_binding extension.");
+    }
 
     //#[cfg(not(debug_assertions))]
     let layers = [];

--- a/src/backend/openxr/input.rs
+++ b/src/backend/openxr/input.rs
@@ -521,5 +521,68 @@ fn suggest_bindings(
         ],
     )?;
 
+    let path = instance.string_to_path("/interaction_profiles/microsoft/motion_controller")?;
+    instance.suggest_interaction_profile_bindings(
+        path,
+        &[
+            xr::Binding::new(
+                &hands[0].action_pose,
+                instance.string_to_path("/user/hand/left/input/aim/pose")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_pose,
+                instance.string_to_path("/user/hand/right/input/aim/pose")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_click,
+                instance.string_to_path("/user/hand/right/input/trigger/value")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_grab,
+                instance.string_to_path("/user/hand/left/input/squeeze/click")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_grab,
+                instance.string_to_path("/user/hand/right/input/squeeze/click")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_click_modifier_right,
+                instance.string_to_path("/user/hand/left/input/trackpad/dpad_up")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_click_modifier_right,
+                instance.string_to_path("/user/hand/right/input/trackpad/dpad_up")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_click_modifier_middle,
+                instance.string_to_path("/user/hand/left/input/trackpad/dpad_down")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_click_modifier_middle,
+                instance.string_to_path("/user/hand/right/input/trackpad/dpad_down")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_scroll,
+                instance.string_to_path("/user/hand/left/input/thumbstick/y")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_scroll,
+                instance.string_to_path("/user/hand/right/input/thumbstick/y")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_show_hide,
+                instance.string_to_path("/user/hand/left/input/menu/click")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_haptics,
+                instance.string_to_path("/user/hand/left/output/haptic")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_haptics,
+                instance.string_to_path("/user/hand/right/output/haptic")?,
+            ),
+        ],
+    )?;
+
     Ok(())
 }

--- a/src/backend/openxr/input.rs
+++ b/src/backend/openxr/input.rs
@@ -584,5 +584,68 @@ fn suggest_bindings(
         ],
     )?;
 
+    let path = instance.string_to_path("/interaction_profiles/hp/mixed_reality_controller")?;
+    instance.suggest_interaction_profile_bindings(
+        path,
+        &[
+            xr::Binding::new(
+                &hands[0].action_pose,
+                instance.string_to_path("/user/hand/left/input/aim/pose")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_pose,
+                instance.string_to_path("/user/hand/right/input/aim/pose")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_click,
+                instance.string_to_path("/user/hand/right/input/trigger/value")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_grab,
+                instance.string_to_path("/user/hand/left/input/squeeze/value")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_grab,
+                instance.string_to_path("/user/hand/right/input/squeeze/value")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_click_modifier_right,
+                instance.string_to_path("/user/hand/left/input/y/click")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_click_modifier_right,
+                instance.string_to_path("/user/hand/right/input/b/click")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_click_modifier_middle,
+                instance.string_to_path("/user/hand/left/input/x/click")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_click_modifier_middle,
+                instance.string_to_path("/user/hand/right/input/a/click")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_scroll,
+                instance.string_to_path("/user/hand/left/input/thumbstick/y")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_scroll,
+                instance.string_to_path("/user/hand/right/input/thumbstick/y")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_show_hide,
+                instance.string_to_path("/user/hand/left/input/menu/click")?,
+            ),
+            xr::Binding::new(
+                &hands[0].action_haptics,
+                instance.string_to_path("/user/hand/left/output/haptic")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_haptics,
+                instance.string_to_path("/user/hand/right/output/haptic")?,
+            ),
+        ],
+    )?;
+
     Ok(())
 }


### PR DESCRIPTION
This adds bindings for the original Windows Mixed Reality controllers. I've only tested it with the Lenovo Explorer controllers, but it might work with the Samsung WMR controllers too.

Edit: added (untested) bindings for HP Reverb G2 controllers.

Edit: This works mostly with my controllers, but the scrolling is reversed and the existing deadzone isn't large enough so it isn't really usable.