### PR TITLE
feat(openxr): Monado playspace mover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,7 +1040,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1050,6 +1050,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2303,6 +2322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2879,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,6 +3350,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -3916,6 +3979,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
@@ -4250,6 +4323,7 @@ dependencies = [
  "json",
  "json5",
  "libc",
+ "libloading 0.8.3",
  "log",
  "log-panics",
  "once_cell",
@@ -4263,6 +4337,7 @@ dependencies = [
  "serde_yaml",
  "smallvec",
  "strum",
+ "sysinfo",
  "thiserror",
  "vulkano",
  "vulkano-shaders",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ input-linux = "0.6.0"
 json = { version = "0.12.4", optional = true }
 json5 = "0.4.1"
 libc = "0.2.153"
+libloading = "0.8.3"
 log = "0.4.21"
 once_cell = "1.19.0"
 openxr = { version = "0.17.1", features = ["linked"], optional = true }
@@ -48,6 +49,7 @@ serde_json = "1.0.113"
 serde_yaml = "0.9.34"
 smallvec = "1.11.0"
 strum = { version = "0.26.2", features = ["derive"] }
+sysinfo = { version = "0.30.0", optional = true }
 thiserror = "1.0.56"
 vulkano = { git = "https://github.com/vulkano-rs/vulkano", rev = "94f50f1" }
 vulkano-shaders = { git = "https://github.com/vulkano-rs/vulkano", rev = "94f50f1" }
@@ -59,7 +61,7 @@ log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 [features]
 default = ["openvr", "openxr", "osc", "x11", "wayland"]
 openvr = ["dep:ovr_overlay", "dep:json"]
-openxr = ["dep:openxr"]
+openxr = ["dep:openxr", "dep:sysinfo"]
 osc = ["dep:rosc"]
 x11 = ["wlx-capture/xshm"]
 wayland = ["wlx-capture/pipewire", "wlx-capture/wlr"]

--- a/src/backend/openxr/input.rs
+++ b/src/backend/openxr/input.rs
@@ -51,6 +51,7 @@ pub(super) struct OpenXrHandSource {
     action_scroll: xr::Action<f32>,
     action_alt_click: xr::Action<f32>,
     action_show_hide: xr::Action<bool>,
+    action_space_drag: xr::Action<bool>,
     action_click_modifier_right: xr::Action<bool>,
     action_click_modifier_middle: xr::Action<bool>,
     action_move_mouse: xr::Action<bool>,
@@ -201,6 +202,12 @@ impl OpenXrHand {
             .state(&xr.session, xr::Path::NULL)?
             .current_state;
 
+        pointer.now.space_drag = self
+            .source
+            .action_space_drag
+            .state(&xr.session, xr::Path::NULL)?
+            .current_state;
+
         Ok(())
     }
 }
@@ -259,6 +266,11 @@ impl OpenXrHandSource {
             &format!("{} hand haptics", side),
             &[],
         )?;
+        let action_space_drag = action_set.create_action::<bool>(
+            &format!("{}_space_drag", side),
+            &format!("{} hand space drag", side),
+            &[],
+        )?;
 
         Ok(Self {
             action_pose,
@@ -271,6 +283,7 @@ impl OpenXrHandSource {
             action_click_modifier_middle,
             action_move_mouse,
             action_haptics,
+            action_space_drag,
         })
     }
 }
@@ -381,6 +394,10 @@ fn suggest_bindings(
                 instance.string_to_path("/user/hand/right/input/trigger/touch")?,
             ),
             xr::Binding::new(
+                &hands[0].action_space_drag,
+                instance.string_to_path("/user/hand/left/input/menu/click")?,
+            ),
+            xr::Binding::new(
                 &hands[0].action_haptics,
                 instance.string_to_path("/user/hand/left/output/haptic")?,
             ),
@@ -438,6 +455,10 @@ fn suggest_bindings(
             xr::Binding::new(
                 &hands[0].action_show_hide,
                 instance.string_to_path("/user/hand/left/input/b/click")?,
+            ),
+            xr::Binding::new(
+                &hands[1].action_space_drag,
+                instance.string_to_path("/user/hand/right/input/b/click")?,
             ),
             xr::Binding::new(
                 &hands[0].action_click_modifier_right,

--- a/src/backend/openxr/playspace.rs
+++ b/src/backend/openxr/playspace.rs
@@ -1,0 +1,98 @@
+use std::ffi::c_void;
+
+use glam::Vec3A;
+use libloading::{Library, Symbol};
+
+use crate::{backend::common::OverlayContainer, state::AppState};
+
+use super::{helpers, input::DoubleClickCounter, overlay::OpenXrOverlayData};
+
+pub(super) struct PlayspaceMover {
+    drag_hand: Option<usize>,
+    offset: Vec3A,
+    start_position: Vec3A,
+
+    double_click_counter: DoubleClickCounter,
+
+    libmonado: Library,
+    mnd_root: *mut c_void,
+    playspace_move: extern "C" fn(*mut c_void, f32, f32, f32) -> i32,
+}
+
+impl PlayspaceMover {
+    pub fn try_new() -> anyhow::Result<Self> {
+        unsafe {
+            let libmonado = helpers::find_libmonado()?;
+
+            let root_create: Symbol<extern "C" fn(*mut *mut c_void) -> i32> =
+                libmonado.get(b"mnd_root_create\0")?;
+            let playspace_move: Symbol<extern "C" fn(*mut c_void, f32, f32, f32) -> i32> =
+                libmonado.get(b"mnd_root_playspace_move\0")?;
+            let playspace_move_raw = *playspace_move;
+
+            let mut root: *mut c_void = std::ptr::null_mut();
+
+            let ret = root_create(&mut root);
+
+            if ret != 0 {
+                anyhow::bail!("Failed to create root, code: {}", ret);
+            }
+
+            Ok(Self {
+                drag_hand: None,
+                offset: Vec3A::ZERO,
+                start_position: Vec3A::ZERO,
+
+                double_click_counter: DoubleClickCounter::new(),
+
+                libmonado,
+                mnd_root: root,
+                playspace_move: playspace_move_raw,
+            })
+        }
+    }
+
+    pub fn update(&mut self, overlays: &mut OverlayContainer<OpenXrOverlayData>, state: &AppState) {
+        if let Some(hand) = self.drag_hand {
+            let pointer = &state.input_state.pointers[hand];
+            if !pointer.now.space_drag {
+                self.drag_hand = None;
+                log::info!("End space drag");
+                return;
+            }
+
+            let hand_pos = state.input_state.pointers[hand].pose.translation;
+            let relative_pos = hand_pos - self.start_position;
+
+            overlays.iter_mut().for_each(|overlay| {
+                if overlay.state.grabbable {
+                    overlay.state.dirty = true;
+                    overlay.state.transform.translation += relative_pos * -1.0;
+                }
+            });
+
+            self.offset += relative_pos;
+            self.apply_offset();
+        } else {
+            for (i, pointer) in state.input_state.pointers.iter().enumerate() {
+                if pointer.now.space_drag
+                    && !pointer.before.space_drag
+                    && self.double_click_counter.click()
+                {
+                    self.drag_hand = Some(i);
+                    self.start_position = pointer.pose.translation;
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.offset = Vec3A::ZERO;
+        self.start_position = Vec3A::ZERO;
+    }
+
+    fn apply_offset(&mut self) {
+        (self.playspace_move)(self.mnd_root, self.offset.x, self.offset.y, self.offset.z);
+    }
+}


### PR DESCRIPTION
Cleaned up https://github.com/galister/wlx-overlay-s/pull/40 so that it doesn't break on un-patched Monado and WiVRn.

Monado playspace mover branch by Rin: https://gitlab.freedesktop.org/RinLovesYou/monado

Those who need Playspace mover with Vive trackers: https://github.com/galister/wlx-overlay-s/pull/40#issuecomment-2122842036

When using Monado, WlxOverlay-S will automatically find libmonado.so and initialize the playspace mover, if the Monado version is compatible.

On WiVRn, I did not have luck getting it to work myself, but the following extra steps are needed, in case you want to test:
- in the server build folder, `ninja libmonado.so`
- export the absolute path of that as `LIBMONADO_PATH` when launching WlxOverlay-S