### PR TITLE
Fix mirrors spawning behind head

### DIFF
--- a/src/overlays/mirror.rs
+++ b/src/overlays/mirror.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use futures::{Future, FutureExt};
-use glam::vec3a;
 use wlx_capture::pipewire::{pipewire_select_screen, PipewireCapture, PipewireSelectScreenResult};
 
 use crate::{
@@ -137,7 +136,6 @@ pub fn new_mirror(
         show_hide,
         want_visible: true,
         spawn_scale: 0.5 * session.config.desktop_view_scale,
-        spawn_point: vec3a(0., 0.5, 0.5),
         ..Default::default()
     };
     let backend = Box::new(SplitOverlayBackend {


### PR DESCRIPTION
Now spawns directly in front of head. `(0, 0.5, -0.5)` could have been one fix, but the default of `(0, 0, -1)` seems ok too.