### PR TITLE
feat: XR binding for playspace reset

### DIFF
--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -73,6 +73,9 @@ impl InputState {
                 if hand.now.space_rotate != hand.before.space_rotate {
                     log::debug!("Hand {}: space_rotate {}", hand.idx, hand.now.space_rotate);
                 }
+                if hand.now.space_reset != hand.before.space_reset {
+                    log::debug!("Hand {}: space_reset {}", hand.idx, hand.now.space_reset);
+                }
                 if hand.now.click_modifier_right != hand.before.click_modifier_right {
                     log::debug!(
                         "Hand {}: click_modifier_right {}",
@@ -192,6 +195,7 @@ pub struct PointerState {
     pub show_hide: bool,
     pub space_drag: bool,
     pub space_rotate: bool,
+    pub space_reset: bool,
     pub click_modifier_right: bool,
     pub click_modifier_middle: bool,
     pub move_mouse: bool,

--- a/src/backend/openxr/input.rs
+++ b/src/backend/openxr/input.rs
@@ -156,6 +156,7 @@ pub(super) struct OpenXrHandSource {
     action_show_hide: CustomClickAction,
     action_space_drag: CustomClickAction,
     action_space_rotate: CustomClickAction,
+    action_space_reset: CustomClickAction,
     action_modifier_right: CustomClickAction,
     action_modifier_middle: CustomClickAction,
     action_move_mouse: CustomClickAction,
@@ -377,6 +378,11 @@ impl OpenXrHand {
                 .action_space_rotate
                 .state(pointer.before.space_rotate, xr, session)?;
 
+        pointer.now.space_reset =
+            self.source
+                .action_space_reset
+                .state(pointer.before.space_reset, xr, session)?;
+
         Ok(())
     }
 }
@@ -410,6 +416,7 @@ impl OpenXrHandSource {
             action_show_hide: CustomClickAction::new(action_set, "show_hide", side)?,
             action_space_drag: CustomClickAction::new(action_set, "space_drag", side)?,
             action_space_rotate: CustomClickAction::new(action_set, "space_rotate", side)?,
+            action_space_reset: CustomClickAction::new(action_set, "space_reset", side)?,
             action_modifier_right: CustomClickAction::new(
                 action_set,
                 "click_modifier_right",
@@ -580,6 +587,14 @@ fn suggest_bindings(instance: &xr::Instance, hands: &[&OpenXrHandSource; 2]) -> 
         );
 
         add_custom!(
+            profile.space_reset,
+            &hands[0].action_space_reset,
+            &hands[1].action_space_reset,
+            bindings,
+            instance
+        );
+
+        add_custom!(
             profile.click_modifier_right,
             &hands[0].action_modifier_right,
             &hands[1].action_modifier_right,
@@ -634,6 +649,7 @@ struct OpenXrActionConfProfile {
     show_hide: Option<OpenXrActionConfAction>,
     space_drag: Option<OpenXrActionConfAction>,
     space_rotate: Option<OpenXrActionConfAction>,
+    space_reset: Option<OpenXrActionConfAction>,
     click_modifier_right: Option<OpenXrActionConfAction>,
     click_modifier_middle: Option<OpenXrActionConfAction>,
     move_mouse: Option<OpenXrActionConfAction>,

--- a/src/backend/openxr/openxr_actions.json5
+++ b/src/backend/openxr/openxr_actions.json5
@@ -15,6 +15,9 @@
 // -- space_rotate --
 // rotate your stage (playspace rotate, WIP)
 //
+// -- space_reset --
+// reset your stage (reset the offset from playspace drag)
+//
 // -- click_modifier_right --
 // while this is held, your pointer will turn ORANGE and your mouse clicks will be RIGHT clicks
 //
@@ -131,6 +134,10 @@
     space_drag: {
       left: "/user/hand/left/input/trackpad/force",
       // right trackpad is alt_click
+    },
+    space_reset: {
+      double_click: true,
+      left: "/user/hand/left/input/trackpad/force",
     },
     click_modifier_right: {
       left: "/user/hand/left/input/b/touch",

--- a/src/backend/openxr/playspace.rs
+++ b/src/backend/openxr/playspace.rs
@@ -55,6 +55,16 @@ impl PlayspaceMover {
         state: &AppState,
         monado: &mut Monado,
     ) {
+        for (_i, pointer) in state.input_state.pointers.iter().enumerate() {
+            if pointer.now.space_reset {
+                if !pointer.before.space_reset {
+                    log::info!("Space reset");
+                    self.reset_offset(monado);
+                }
+                return;
+            }
+        }
+
         if let Some(mut data) = self.rotate.take() {
             let pointer = &state.input_state.pointers[data.hand];
             if !pointer.now.space_rotate {


### PR DESCRIPTION
On index if you double click the left touchpad, you'll reset the playspace offset. This is faster than having the config panel open.
It runs first in the update function so that the second click to reset doesn't count as an attempt to start another playspace drag. For that, you must press it a third time.