### PR TITLE
contrib: add systemd service for Monado autostart

### DIFF
--- a/contrib/wlx-overlay-s.service
+++ b/contrib/wlx-overlay-s.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=wlx-overlay-s - Lightweight OpenXR/OpenVR overlay for Wayland and X11 desktops
+After=monado.service
+BindsTo=monado.service
+Requires=monado.socket
+Requires=graphical-session.target
+
+[Service]
+ExecStart=@prefix@/bin/wlx-overlay-s
+
+[Install]
+WantedBy=monado.service


### PR DESCRIPTION
Using this service file, we can autostart wlx-overlay-s alongside Monado's systemd service.

A packager should substitute `@prefix@` with the installation prefix of the binary and place the file in one of systemd's user services directories (i.e. `/usr/share/systemd/user/`).

Users can then make sure the service is enabled using `systemctl --user enable wlx-overlay-s.service` and just start Monado using `systemctl --user start monado.service`.
