### PR TITLE
WayVR: `shown_at_start` app param support

### DIFF
--- a/src/overlays/wayvr.rs
+++ b/src/overlays/wayvr.rs
@@ -328,7 +328,7 @@ where
                 conf_display.width,
                 conf_display.height,
                 display_handle,
-                conf_display.scale,
+                conf_display.scale.unwrap_or(1.0),
             )?;
 
             if let Some(attach_to) = &conf_display.attach_to {

--- a/src/res/wayvr.yaml
+++ b/src/res/wayvr.yaml
@@ -16,7 +16,6 @@ displays:
   Disp1:
     width: 640
     height: 480
-    scale: 1.25
   Disp2:
     width: 1280
     height: 720
@@ -29,6 +28,7 @@ catalogs:
         target_display: "Disp1"
         exec: "kcalc"
         env: ["FOO=bar"]
+        shown_at_start: false
 
       - name: "htop"
         target_display: "Watch"

--- a/src/state.rs
+++ b/src/state.rs
@@ -91,12 +91,21 @@ impl AppState {
             shaders.insert("frag_swapchain", shader);
         }
 
+        #[cfg(feature = "wayvr")]
+        let mut tasks = TaskContainer::new();
+
+        #[cfg(not(feature = "wayvr"))]
+        let tasks = TaskContainer::new();
+
         let session = AppSession::load();
+
+        #[cfg(feature = "wayvr")]
+        session.wayvr_config.post_load(&mut tasks);
 
         Ok(AppState {
             fc: FontCache::new(session.config.primary_font.clone())?,
             session,
-            tasks: TaskContainer::new(),
+            tasks,
             graphics,
             input_state: InputState::new(),
             hid_provider: crate::hid::initialize(),


### PR DESCRIPTION
This PR allows for the launch of the WayVR app immediately after wlx startup, via setting `shown_at_start` app parameter to `true` (see wayvr.yaml).