### PR TITLE
WayVR: External process support, various tweaks and bugfixes

### DIFF
--- a/src/backend/openvr/mod.rs
+++ b/src/backend/openvr/mod.rs
@@ -328,9 +328,7 @@ pub fn openvr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
         };
 
         #[cfg(feature = "wayvr")]
-        if let Some(wayvr) = &state.wayvr {
-            wayvr.borrow_mut().tick_events()?;
-        }
+        crate::overlays::wayvr::tick_events::<OpenVrOverlayData>(&mut state, &mut overlays)?;
 
         log::trace!("Rendering frame");
 

--- a/src/backend/openxr/mod.rs
+++ b/src/backend/openxr/mod.rs
@@ -364,9 +364,7 @@ pub fn openxr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
         }
 
         #[cfg(feature = "wayvr")]
-        if let Some(wayvr) = &app_state.wayvr {
-            wayvr.borrow_mut().tick_events()?;
-        }
+        crate::overlays::wayvr::tick_events::<OpenXrOverlayData>(&mut app_state, &mut overlays)?;
 
         for o in overlays.iter_mut() {
             if !o.state.want_visible {

--- a/src/backend/wayvr/display.rs
+++ b/src/backend/wayvr/display.rs
@@ -50,6 +50,7 @@ pub struct Display {
     pub visible: bool,
     pub overlay_id: Option<OverlayID>,
     pub wants_redraw: bool,
+    pub primary: bool,
     wm: Rc<RefCell<window::WindowManager>>,
     pub displayed_windows: Vec<DisplayWindow>,
     wayland_env: super::WaylandEnv,
@@ -81,6 +82,7 @@ impl Display {
         width: u32,
         height: u32,
         name: &str,
+        primary: bool,
     ) -> anyhow::Result<Self> {
         let tex_format = ffi::RGBA;
         let internal_format = ffi::RGBA8;
@@ -116,6 +118,7 @@ impl Display {
             gles_texture,
             wayland_env,
             visible: true,
+            primary,
             overlay_id: None,
             tasks: SyncEventQueue::new(),
         })
@@ -239,7 +242,12 @@ impl Display {
 
     pub fn set_visible(&mut self, visible: bool) {
         log::info!("Display \"{}\" visible: {}", self.name.as_str(), visible);
-        self.visible = visible;
+        if self.visible != visible {
+            self.visible = visible;
+            if visible {
+                self.wants_redraw = true;
+            }
+        }
     }
 
     pub fn send_mouse_move(&self, manager: &mut WayVRManager, x: u32, y: u32) {

--- a/src/backend/wayvr/process.rs
+++ b/src/backend/wayvr/process.rs
@@ -2,7 +2,7 @@ use crate::gen_id;
 
 use super::display;
 
-pub struct Process {
+pub struct WayVRProcess {
     pub auth_key: String,
     pub child: std::process::Child,
     pub display_handle: display::DisplayHandle,
@@ -12,7 +12,40 @@ pub struct Process {
     pub env: Vec<(String, String)>,
 }
 
-impl Drop for Process {
+pub struct ExternalProcess {
+    pub pid: u32,
+    pub display_handle: display::DisplayHandle,
+}
+
+pub enum Process {
+    Managed(WayVRProcess),     // Process spawned by WayVR
+    External(ExternalProcess), // External process not directly controlled by us
+}
+
+impl Process {
+    pub fn display_handle(&self) -> display::DisplayHandle {
+        match self {
+            Process::Managed(p) => p.display_handle,
+            Process::External(p) => p.display_handle,
+        }
+    }
+
+    pub fn is_running(&mut self) -> bool {
+        match self {
+            Process::Managed(p) => p.is_running(),
+            Process::External(p) => p.is_running(),
+        }
+    }
+
+    pub fn terminate(&mut self) {
+        match self {
+            Process::Managed(p) => p.terminate(),
+            Process::External(p) => p.terminate(),
+        }
+    }
+}
+
+impl Drop for WayVRProcess {
     fn drop(&mut self) {
         log::info!(
             "Sending SIGTERM (graceful exit) to process {}",
@@ -22,8 +55,8 @@ impl Drop for Process {
     }
 }
 
-impl Process {
-    pub fn is_running(&mut self) -> bool {
+impl WayVRProcess {
+    fn is_running(&mut self) -> bool {
         match self.child.try_wait() {
             Ok(Some(_exit_status)) => false,
             Ok(None) => true,
@@ -35,11 +68,31 @@ impl Process {
         }
     }
 
-    pub fn terminate(&mut self) {
+    fn terminate(&mut self) {
         unsafe {
             // Gracefully stop process
             libc::kill(self.child.id() as i32, libc::SIGTERM);
         }
+    }
+}
+
+impl ExternalProcess {
+    fn is_running(&self) -> bool {
+        if self.pid == 0 {
+            false
+        } else {
+            std::fs::metadata(format!("/proc/{}", self.pid)).is_ok()
+        }
+    }
+
+    fn terminate(&mut self) {
+        if self.pid != 0 {
+            unsafe {
+                // send SIGINT (^C)
+                libc::kill(self.pid as i32, libc::SIGINT);
+            }
+        }
+        self.pid = 0;
     }
 }
 
@@ -48,8 +101,17 @@ gen_id!(ProcessVec, Process, ProcessCell, ProcessHandle);
 pub fn find_by_pid(processes: &ProcessVec, pid: u32) -> Option<ProcessHandle> {
     for (idx, cell) in processes.vec.iter().enumerate() {
         if let Some(cell) = cell {
-            if cell.obj.child.id() == pid {
-                return Some(ProcessVec::get_handle(cell, idx));
+            match &cell.obj {
+                Process::Managed(wayvr_process) => {
+                    if wayvr_process.child.id() == pid {
+                        return Some(ProcessVec::get_handle(cell, idx));
+                    }
+                }
+                Process::External(external_process) => {
+                    if external_process.pid == pid {
+                        return Some(ProcessVec::get_handle(cell, idx));
+                    }
+                }
             }
         }
     }

--- a/src/res/wayvr.yaml
+++ b/src/res/wayvr.yaml
@@ -5,6 +5,10 @@
 
 version: 1
 
+# Set to true if you want to make Wyland server instantly available
+# (used for remote starting external processes)
+run_compositor_at_start: false 
+
 displays:
   Watch:
     width: 400
@@ -16,6 +20,7 @@ displays:
   Disp1:
     width: 640
     height: 480
+    primary: true # Required if you want to attach external processes (not spawned by WayVR itself) without WAYVR_DISPLAY_NAME set
   Disp2:
     width: 1280
     height: 720

--- a/src/state.rs
+++ b/src/state.rs
@@ -100,7 +100,7 @@ impl AppState {
         let session = AppSession::load();
 
         #[cfg(feature = "wayvr")]
-        session.wayvr_config.post_load(&mut tasks);
+        let wayvr = session.wayvr_config.post_load(&mut tasks)?;
 
         Ok(AppState {
             fc: FontCache::new(session.config.primary_font.clone())?,
@@ -116,7 +116,7 @@ impl AppState {
             keyboard_focus: KeyboardFocus::PhysicalScreen,
 
             #[cfg(feature = "wayvr")]
-            wayvr: None,
+            wayvr,
         })
     }
 
@@ -126,7 +126,6 @@ impl AppState {
         if let Some(wvr) = &self.wayvr {
             Ok(wvr.clone())
         } else {
-            log::info!("Initializing WayVR");
             let wayvr = Rc::new(RefCell::new(WayVR::new()?));
             self.wayvr = Some(wayvr.clone());
             Ok(wayvr)


### PR DESCRIPTION
- Support for foreign wayland clients, WayVR process is now separated into managed and external one
- Add `run_compositor_at_start` global param
- Add `primary` display param
- Export WAYLAND_DISPLAY number into XDG_RUNTIME_DIR directory
- Bugfix: Redraw event is not triggered after despawning a process
- Sanitization in WayVRConfig::post_load()