### PR TITLE
Enable modifier key with purple laser

### DIFF
--- a/src/overlays/keyboard.rs
+++ b/src/overlays/keyboard.rs
@@ -225,9 +225,16 @@ fn key_press(
         Some(KeyButtonData::Key { vk, pressed }) => {
             data.key_click(app);
 
-            if let PointerMode::Right = mode {
-                data.modifiers |= SHIFT;
-                set_modifiers(app, data.modifiers);
+            match mode {
+                PointerMode::Right => {
+                    data.modifiers |= SHIFT;
+                    app.hid_provider.set_modifiers(data.modifiers);
+                },
+                PointerMode::Middle => {
+                    data.modifiers |= CTRL;
+                    app.hid_provider.set_modifiers(data.modifiers);
+                },
+                _ => {},
             }
 
             send_key(app, *vk, true);

--- a/src/res/keyboard.yaml
+++ b/src/res/keyboard.yaml
@@ -43,6 +43,15 @@ main_layout:
     - ["LShift", "Oem102", "Z", "X", "C", "V", "B", "N", "M", "Comma", "Period", "Oem2", "RShift", ~, "Up", ~, "KP_1", "KP_2", "KP_3", "KP_Enter"]
     - ["LCtrl", "LSuper", "LAlt", "Space", "Meta", "RSuper", "Menu", "RCtrl", ~, "Left", "Down", "Right", ~, "KP_0", "KP_Decimal", ~]
 
+# When using the purple pointer...
+# None   - No special functionality when using purple pointer (Default)
+# Shift  - Use same functionality as the orange pointer
+# Ctrl   - Use Main layout with Ctrl modifier
+# Alt    - Use Main layout with Alt modifier
+# Super  - Use Main layout with Super (WinKey) modifier
+# Meta   - Use Main layout with Meta (AltGr) modifier
+alt_modifier: None
+
 # Shell commands to be used in a layout.
 # Value is an array of string arguments.
 exec_commands:


### PR DESCRIPTION
This patch adds the ability to apply the CTRL modifier when pressing keys on the keyboard while the purple laser is active.