### PR TITLE
WayVR: wl_output protocol support

### DIFF
--- a/contrib/wayvr/README.md
+++ b/contrib/wayvr/README.md
@@ -30,7 +30,7 @@ That's it; you're all set!
 
 ### Supported software
 
-- Basically all Qt applications (they work out of the box)
+- Basically all Qt and GTK applications (they work out of the box)
 - Most XWayland applications via `cage`
 
 ### XWayland

--- a/src/backend/wayvr/comp.rs
+++ b/src/backend/wayvr/comp.rs
@@ -5,9 +5,11 @@ use smithay::reexports::wayland_server;
 use smithay::reexports::wayland_server::protocol::{wl_buffer, wl_seat, wl_surface};
 use smithay::reexports::wayland_server::Resource;
 use smithay::wayland::buffer::BufferHandler;
+use smithay::wayland::output::OutputHandler;
 use smithay::wayland::shm::{ShmHandler, ShmState};
 use smithay::{
-    delegate_compositor, delegate_data_device, delegate_seat, delegate_shm, delegate_xdg_shell,
+    delegate_compositor, delegate_data_device, delegate_output, delegate_seat, delegate_shm,
+    delegate_xdg_shell,
 };
 use std::collections::HashSet;
 use std::os::fd::OwnedFd;
@@ -168,11 +170,14 @@ impl ShmHandler for Application {
     }
 }
 
+impl OutputHandler for Application {}
+
 delegate_xdg_shell!(Application);
 delegate_compositor!(Application);
 delegate_shm!(Application);
 delegate_seat!(Application);
 delegate_data_device!(Application);
+delegate_output!(Application);
 
 pub fn send_frames_surface_tree(surface: &wl_surface::WlSurface, time: u32) {
     with_surface_tree_downward(

--- a/src/backend/wayvr/display.rs
+++ b/src/backend/wayvr/display.rs
@@ -229,13 +229,13 @@ impl Display {
 
         let mut frame = renderer.render(size, Transform::Normal)?;
 
-        let clear_opacity = if self.displayed_windows.is_empty() {
-            0.5
+        let clear_color = if self.displayed_windows.is_empty() {
+            Color32F::new(1.0, 1.0, 1.0, 0.5)
         } else {
-            0.0
+            Color32F::new(0.0, 0.0, 0.0, 0.0)
         };
 
-        frame.clear(Color32F::new(1.0, 1.0, 1.0, clear_opacity), &[damage])?;
+        frame.clear(clear_color, &[damage])?;
 
         draw_render_elements(&mut frame, 1.0, &elements, &[damage])?;
 

--- a/src/backend/wayvr/mod.rs
+++ b/src/backend/wayvr/mod.rs
@@ -20,6 +20,7 @@ use smallvec::SmallVec;
 use smithay::{
     backend::renderer::gles::GlesRenderer,
     input::SeatState,
+    output::{Mode, Output},
     reexports::wayland_server::{self, backend::ClientId},
     wayland::{
         compositor,
@@ -113,6 +114,29 @@ impl WayVR {
         let shm = ShmState::new::<Application>(&dh, Vec::new());
         let data_device = DataDeviceState::new::<Application>(&dh);
         let mut seat = seat_state.new_wl_seat(&dh, "wayvr");
+
+        let dummy_width = 1280;
+        let dummy_height = 720;
+        let dummy_milli_hz = 60000; /* refresh rate in millihertz */
+
+        let output = Output::new(
+            String::from("wayvr_display"),
+            smithay::output::PhysicalProperties {
+                size: (dummy_width, dummy_height).into(),
+                subpixel: smithay::output::Subpixel::None,
+                make: String::from("Completely Legit"),
+                model: String::from("Virtual WayVR Display"),
+            },
+        );
+
+        let mode = Mode {
+            refresh: dummy_milli_hz,
+            size: (dummy_width, dummy_height).into(),
+        };
+
+        output.change_current_state(Some(mode), None, None, None);
+        output.set_preferred(mode);
+        let _global = output.create_global::<Application>(&dh);
 
         let seat_keyboard = seat.add_keyboard(
             Default::default(),


### PR DESCRIPTION
In a nutshell: Native Chromium and GTK support, without using cage.