### PR TITLE
Send device battery levels over OSC

### DIFF
--- a/src/backend/openvr/mod.rs
+++ b/src/backend/openvr/mod.rs
@@ -324,7 +324,7 @@ pub fn openvr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
 
         #[cfg(feature = "osc")]
         if let Some(ref mut sender) = osc_sender {
-            let _ = sender.send_params(&overlays);
+            let _ = sender.send_params(&overlays, &state); // i love inconsistent naming; in openxr.rs `state` is called `app_state`
         };
 
         #[cfg(feature = "wayvr")]

--- a/src/backend/openvr/mod.rs
+++ b/src/backend/openvr/mod.rs
@@ -324,7 +324,7 @@ pub fn openvr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
 
         #[cfg(feature = "osc")]
         if let Some(ref mut sender) = osc_sender {
-            let _ = sender.send_params(&overlays, &state); // i love inconsistent naming; in openxr.rs `state` is called `app_state`
+            let _ = sender.send_params(&overlays, &state);
         };
 
         #[cfg(feature = "wayvr")]

--- a/src/backend/openxr/mod.rs
+++ b/src/backend/openxr/mod.rs
@@ -304,7 +304,7 @@ pub fn openxr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
 
         #[cfg(feature = "osc")]
         if let Some(ref mut sender) = osc_sender {
-            let _ = sender.send_params(&overlays);
+            let _ = sender.send_params(&overlays, &app_state);
         };
 
         let (_, views) = xr_state.session.locate_views(

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -16,7 +16,8 @@ use crate::{
 use super::common::OverlayContainer;
 
 pub struct OscSender {
-    last_sent: Instant,
+    last_sent_overlay: Instant,
+    last_sent_battery: Instant,
     upstream: UdpSocket,
 }
 
@@ -34,7 +35,8 @@ impl OscSender {
 
         Ok(Self {
             upstream,
-            last_sent: Instant::now(),
+            last_sent_overlay: Instant::now(),
+            last_sent_battery: Instant::now(),
         })
     }
 
@@ -55,91 +57,96 @@ impl OscSender {
     where
         D: Default,
     {
-        if self.last_sent.elapsed().as_millis() < 100 {
-            return Ok(());
-        }
+        // send overlay data every 0.1 seconds
+        if self.last_sent_overlay.elapsed().as_millis() >= 100 {
+            self.last_sent_overlay = Instant::now();
 
-        let mut num_overlays = 0;
-        let mut has_keyboard = false;
-        let mut has_wrist = false;
+            let mut num_overlays = 0;
+            let mut has_keyboard = false;
+            let mut has_wrist = false;
 
-        for o in overlays.iter() {
-            if !o.state.want_visible {
-                continue;
-            }
-            match o.state.name.as_ref() {
-                WATCH_NAME => has_wrist = true,
-                KEYBOARD_NAME => has_keyboard = true,
-                _ => {
-                    if o.state.interactable {
-                        num_overlays += 1
+            for o in overlays.iter() {
+                if !o.state.want_visible {
+                    continue;
+                }
+                match o.state.name.as_ref() {
+                    WATCH_NAME => has_wrist = true,
+                    KEYBOARD_NAME => has_keyboard = true,
+                    _ => {
+                        if o.state.interactable {
+                            num_overlays += 1
+                        }
                     }
                 }
             }
+
+            self.send_message(
+                "/avatar/parameters/isOverlayOpen".into(),
+                vec![OscType::Bool(num_overlays > 0)],
+            )?;
+            self.send_message(
+                "/avatar/parameters/isKeyboardOpen".into(),
+                vec![OscType::Bool(has_keyboard)],
+            )?;
+            self.send_message(
+                "/avatar/parameters/isWristVisible".into(),
+                vec![OscType::Bool(has_wrist)],
+            )?;
+            self.send_message(
+                "/avatar/parameters/openOverlayCount".into(),
+                vec![OscType::Int(num_overlays)],
+            )?;
+
         }
 
-        self.send_message(
-            "/avatar/parameters/isOverlayOpen".into(),
-            vec![OscType::Bool(num_overlays > 0)],
-        )?;
-        self.send_message(
-            "/avatar/parameters/isKeyboardOpen".into(),
-            vec![OscType::Bool(has_keyboard)],
-        )?;
-        self.send_message(
-            "/avatar/parameters/isWristVisible".into(),
-            vec![OscType::Bool(has_wrist)],
-        )?;
-        self.send_message(
-            "/avatar/parameters/openOverlayCount".into(),
-            vec![OscType::Int(num_overlays)],
-        )?;
+        // send battery levels every 10 seconds
+        if self.last_sent_battery.elapsed().as_millis() >= 10000 {
+            self.last_sent_battery = Instant::now();
 
-        // battery levels
-        let mut tracker_idx = 0;
+            let mut tracker_idx = 0;
 
-        for device in &app.input_state.devices {
+            for device in &app.input_state.devices {
 
-            // soc is the battery level (set to device status.charge)
-            let level = device.soc.unwrap_or(-1.0);
-            let parameter;
+                // soc is the battery level (set to device status.charge)
+                let level = device.soc.unwrap_or(-1.0);
+                let parameter;
 
-            match device.role {
-                TrackedDeviceRole::None =>      {parameter = String::from("")}
-                TrackedDeviceRole::Hmd =>       {
-                    // XSOverlay style (float)
-                    // this parameter doesn't exist, but it's a stepping stone for 0-1 values (i presume XSOverlay would use the full name headset and not the abbreviation hmd)
-                    parameter = String::from("headset");
+                match device.role {
+                    TrackedDeviceRole::None =>      {parameter = String::from("")}
+                    TrackedDeviceRole::Hmd =>       {
+                        // XSOverlay style (float)
+                        // this parameter doesn't exist, but it's a stepping stone for 0-1 values (i presume XSOverlay would use the full name headset and not the abbreviation hmd)
+                        parameter = String::from("headset");
 
-                    // legacy OVR Toolkit style (int)
-                    // according to their docs, OVR Toolkit is now supposed to use float 0-1.
-                    // as of 20 Nov 2024 they still use int 0-100, but this may change in a future update.
-                    //TODO: remove once their implementation matches the docs
-                    self.send_message(
-                        "/avatar/parameters/hmdBattery".into(),
-                                      vec![OscType::Int((level * 100.0f32).round() as i32)],
-                    )?;
+                        // legacy OVR Toolkit style (int)
+                        // according to their docs, OVR Toolkit is now supposed to use float 0-1.
+                        // as of 20 Nov 2024 they still use int 0-100, but this may change in a future update.
+                        //TODO: remove once their implementation matches the docs
+                        self.send_message(
+                            "/avatar/parameters/hmdBattery".into(),
+                                        vec![OscType::Int((level * 100.0f32).round() as i32)],
+                        )?;
 
+                    }
+                    TrackedDeviceRole::LeftHand =>  {parameter = String::from("leftController")}
+                    TrackedDeviceRole::RightHand => {parameter = String::from("rightController")}
+                    TrackedDeviceRole::Tracker =>   {parameter = format!("tracker{tracker_idx}"); tracker_idx += 1;}
                 }
-                TrackedDeviceRole::LeftHand =>  {parameter = String::from("leftController")}
-                TrackedDeviceRole::RightHand => {parameter = String::from("rightController")}
-                TrackedDeviceRole::Tracker =>   {parameter = format!("tracker{tracker_idx}"); tracker_idx += 1;}
-            }
 
-            // send battery parameters
-            if !parameter.is_empty() {
+                // send battery parameters
+                if !parameter.is_empty() {
 
-                self.send_message(
-                    format!("/avatar/parameters/{parameter}Battery").into(),
-                                vec![OscType::Float(level)],
-                )?;
-                self.send_message(
-                    format!("/avatar/parameters/{parameter}Charging").into(),
-                                vec![OscType::Bool(device.charging)],
-                )?;
+                    self.send_message(
+                        format!("/avatar/parameters/{parameter}Battery").into(),
+                                    vec![OscType::Float(level)],
+                    )?;
+                    self.send_message(
+                        format!("/avatar/parameters/{parameter}Charging").into(),
+                                    vec![OscType::Bool(device.charging)],
+                    )?;
+                }
             }
         }
-        
 
         Ok(())
     }

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -102,14 +102,14 @@ impl OscSender {
 
             // soc is the battery level (set to device status.charge)
             let level = device.soc.unwrap_or(-1.0);
-            let mut parameter = "";
+            let parameter;
 
             match device.role {
-                TrackedDeviceRole::None =>      {}
+                TrackedDeviceRole::None =>      {parameter = String::from("")}
                 TrackedDeviceRole::Hmd =>       {
                     // XSOverlay style (float)
                     // this parameter doesn't exist, but it's a stepping stone for 0-1 values (i presume XSOverlay would use the full name headset and not the abbreviation hmd)
-                    parameter = "headset";
+                    parameter = String::from("headset");
 
                     // legacy OVR Toolkit style (int)
                     // according to their docs, OVR Toolkit is now supposed to use float 0-1.
@@ -121,43 +121,22 @@ impl OscSender {
                     )?;
 
                 }
-                TrackedDeviceRole::LeftHand =>  {parameter = "leftController"}
-                TrackedDeviceRole::RightHand => {parameter = "rightController"}
-                TrackedDeviceRole::Tracker =>   {
-                    //TODO: the String gets dropped i presume once this block exits (so parameter becomes a null ref)
-                    // get this working, we can remove the duplicated code for sending the parameter below
-                    //parameter = format!("tracker{tracker_idx}").as_str();
-                    //            ^^^^^^ "temporary value dropped" ^^^^^
-
-                    parameter = "tracker";
-                    tracker_idx += 1;
-                }
+                TrackedDeviceRole::LeftHand =>  {parameter = String::from("leftController")}
+                TrackedDeviceRole::RightHand => {parameter = String::from("rightController")}
+                TrackedDeviceRole::Tracker =>   {parameter = format!("tracker{tracker_idx}"); tracker_idx += 1;}
             }
 
-            // send level parameter
+            // send battery parameters
             if !parameter.is_empty() {
-                //TODO: figure out how to put the number in the string in the TrackedDeviceRole section above where we set the parameters
-                if parameter == "tracker" {
-                    self.send_message(
-                        format!("/avatar/parameters/tracker{tracker_idx}Battery").into(),
-                                    vec![OscType::Float(level)],
-                    )?;
-                    self.send_message(
-                        format!("/avatar/parameters/tracker{tracker_idx}Charging").into(),
-                                    vec![OscType::Bool(device.charging)],
-                    )?;
-                }
 
-                else {
-                    self.send_message(
-                        format!("/avatar/parameters/{parameter}Battery").into(),
-                                    vec![OscType::Float(level)],
-                    )?;
-                    self.send_message(
-                        format!("/avatar/parameters/{parameter}Charging").into(),
-                                    vec![OscType::Bool(device.charging)],
-                    )?;
-                }
+                self.send_message(
+                    format!("/avatar/parameters/{parameter}Battery").into(),
+                                vec![OscType::Float(level)],
+                )?;
+                self.send_message(
+                    format!("/avatar/parameters/{parameter}Charging").into(),
+                                vec![OscType::Bool(device.charging)],
+                )?;
             }
         }
         

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -8,6 +8,11 @@ use rosc::{OscMessage, OscPacket, OscType};
 
 use crate::overlays::{keyboard::KEYBOARD_NAME, watch::WATCH_NAME};
 
+use crate::{
+    backend::input::{TrackedDevice, TrackedDeviceRole},
+    state::{AppState},
+};
+
 use super::common::OverlayContainer;
 
 pub struct OscSender {
@@ -46,7 +51,7 @@ impl OscSender {
         Ok(())
     }
 
-    pub fn send_params<D>(&mut self, overlays: &OverlayContainer<D>) -> anyhow::Result<()>
+    pub fn send_params<D>(&mut self, overlays: &OverlayContainer<D>, app: &AppState) -> anyhow::Result<()>
     where
         D: Default,
     {
@@ -89,6 +94,32 @@ impl OscSender {
             "/avatar/parameters/openOverlayCount".into(),
             vec![OscType::Int(num_overlays)],
         )?;
+
+        // battery levels
+        let mut tracker_idx = 0;
+
+        let devices = &app.input_state.devices;
+        for device in devices {
+            match device.role {
+                TrackedDeviceRole::None => {
+
+                }
+                TrackedDeviceRole::Hmd => {
+
+                }
+                TrackedDeviceRole::LeftHand => {
+
+                }
+                TrackedDeviceRole::RightHand => {
+
+                }
+                TrackedDeviceRole::Tracker => {
+                    
+                    tracker_idx += 1;
+                }
+            }
+        }
+        
 
         Ok(())
     }

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -100,8 +100,8 @@ impl OscSender {
 
         for device in &app.input_state.devices {
 
-            // i believe soc is the battery level, based on input.rs (status.charge)
-            let level = device.soc.unwrap();
+            // soc is the battery level (set to device status.charge)
+            let level = device.soc.unwrap_or(-1.0);
             let mut parameter = "";
 
             match device.role {

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -109,7 +109,7 @@ impl OscSender {
                 TrackedDeviceRole::Hmd =>       {
                     // XSOverlay style (float)
                     // this parameter doesn't exist, but it's a stepping stone for 0-1 values (i presume XSOverlay would use the full name headset and not the abbreviation hmd)
-                    parameter = "headsetBattery";
+                    parameter = "headset";
 
                     // legacy OVR Toolkit style (int)
                     // according to their docs, OVR Toolkit is now supposed to use float 0-1.
@@ -121,14 +121,14 @@ impl OscSender {
                     )?;
 
                 }
-                TrackedDeviceRole::LeftHand =>  {parameter = "leftControllerBattery"}
-                TrackedDeviceRole::RightHand => {parameter = "rightControllerBattery"}
+                TrackedDeviceRole::LeftHand =>  {parameter = "leftController"}
+                TrackedDeviceRole::RightHand => {parameter = "rightController"}
                 TrackedDeviceRole::Tracker =>   {
-                    //TODO: the String gets dropped i presume once this block exits (so parameter becomes a null ref), even if i set owner.
-                    //parameter = format!("tracker{tracker_idx}Battery").as_str();
+                    //TODO: the String gets dropped i presume once this block exits (so parameter becomes a null ref)
+                    // get this working, we can remove the duplicated code for sending the parameter below
+                    //parameter = format!("tracker{tracker_idx}").as_str();
                     //            ^^^^^^ "temporary value dropped" ^^^^^
 
-                    //TODO: figure out how to put the number in the string properly as above (which doesn't work)
                     parameter = "tracker";
                     tracker_idx += 1;
                 }
@@ -136,18 +136,26 @@ impl OscSender {
 
             // send level parameter
             if !parameter.is_empty() {
-                //TODO: figure out how to put the number in the string, ideally in the TrackedDeviceRole section where we set the parameters
+                //TODO: figure out how to put the number in the string in the TrackedDeviceRole section above where we set the parameters
                 if parameter == "tracker" {
                     self.send_message(
                         format!("/avatar/parameters/tracker{tracker_idx}Battery").into(),
                                     vec![OscType::Float(level)],
                     )?;
+                    self.send_message(
+                        format!("/avatar/parameters/tracker{tracker_idx}Charging").into(),
+                                    vec![OscType::Bool(device.charging)],
+                    )?;
                 }
 
                 else {
                     self.send_message(
-                        format!("/avatar/parameters/{parameter}").into(),
+                        format!("/avatar/parameters/{parameter}Battery").into(),
                                     vec![OscType::Float(level)],
+                    )?;
+                    self.send_message(
+                        format!("/avatar/parameters/{parameter}Charging").into(),
+                                    vec![OscType::Bool(device.charging)],
                     )?;
                 }
             }


### PR DESCRIPTION
I've edited the osc.rs file to send HMD, controller, and tracker battery levels and charging state over OSC to VRChat.
It takes in AppState as a new parameter, but could probably pass just the raw list of devices unless we want to add more parameters like FPS or IPD, etc.

For now there is a workaround for HMD battery specifically as XSOverlay has no parameter for it, and OVR Toolkit uses an int 0-100. I implement both 0-100 as hmdBattery and 0-1 as headsetBattery.

I can only test the HMD battery on Monado at the moment (WiVRn with PICO 4), so controller batteries, tracker batteries, and SteamVR devices are untested.

Parameters are based on the XSOverlay format, excluding average battery levels but adding charging state. Charging state in my testing is delayed, I expect it only updates when the battery level is updated.
```
headsetBattery (float)
leftControllerBattery (float)
leftControllerCharging (bool)
tracker0Battery (float)
tracker0Charging (bool)
etc...
```