### PR TITLE
OSC: Finish XSOverlay parity

### DIFF
--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -137,9 +137,9 @@ impl OscSender {
                         "rightController"
                     }
                     TrackedDeviceRole::Tracker =>   {
-                        tracker_param = format!("tracker{tracker_count}");
                         tracker_count += 1;
                         tracker_total_bat += level;
+                        tracker_param = format!("tracker{tracker_count}");
                         tracker_param.as_str()
                     }
                 };

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -126,8 +126,8 @@ impl OscSender {
                     TrackedDeviceRole::LeftHand =>  {"leftController"}
                     TrackedDeviceRole::RightHand => {"rightController"}
                     TrackedDeviceRole::Tracker =>   {
-                        tracker_idx += 1;
                         tracker_param = format!("tracker{tracker_idx}");
+                        tracker_idx += 1;
                         tracker_param.as_str()
                     }
                 };


### PR DESCRIPTION
Adds parameters for `averageTrackerBattery` and `averageControllerBattery`.

As before, these are untested since I have no trackers and use WiVRn.

Might want to write some documentation for the OSC parameters, too. Let me know where I should put it and I'll do that if I can.
