### PR TITLE
Add UI button actions to send arbitrary OSC values.

### DIFF
--- a/src/backend/openvr/mod.rs
+++ b/src/backend/openvr/mod.rs
@@ -330,7 +330,7 @@ pub fn openvr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
 
         #[cfg(feature = "osc")]
         if let Some(ref mut sender) = state.osc_sender {
-            let _ = sender.send_params(&overlays, &mut state);
+            let _ = sender.send_params(&overlays, &state.input_state.devices);
         };
 
         #[cfg(feature = "wayvr")]

--- a/src/backend/openvr/mod.rs
+++ b/src/backend/openvr/mod.rs
@@ -124,10 +124,6 @@ pub fn openvr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
     let mut playspace = playspace::PlayspaceMover::new();
     playspace.playspace_changed(&mut compositor_mgr, &mut chaperone_mgr);
 
-    #[cfg(feature = "osc")]
-    let mut osc_sender =
-        crate::backend::osc::OscSender::new(state.session.config.osc_out_port).ok();
-
     set_action_manifest(&mut input_mgr)?;
 
     let mut input_source = OpenVrInputSource::new(&mut input_mgr)?;
@@ -333,8 +329,8 @@ pub fn openvr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
         }
 
         #[cfg(feature = "osc")]
-        if let Some(ref mut sender) = osc_sender {
-            let _ = sender.send_params(&overlays, &state);
+        if let Some(ref mut sender) = state.osc_sender {
+            let _ = sender.send_params(&overlays, &mut state);
         };
 
         #[cfg(feature = "wayvr")]

--- a/src/backend/openxr/mod.rs
+++ b/src/backend/openxr/mod.rs
@@ -109,10 +109,6 @@ pub fn openxr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
             .ok()
     });
 
-    #[cfg(feature = "osc")]
-    let mut osc_sender =
-        crate::backend::osc::OscSender::new(app_state.session.config.osc_out_port).ok();
-
     let (session, mut frame_wait, mut frame_stream) = unsafe {
         let raw_session = helpers::create_overlay_session(
             &xr_instance,
@@ -315,7 +311,7 @@ pub fn openxr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
         }
 
         #[cfg(feature = "osc")]
-        if let Some(ref mut sender) = osc_sender {
+        if let Some(ref mut sender) = app_state.osc_sender {
             let _ = sender.send_params(&overlays, &app_state);
         };
 

--- a/src/backend/openxr/mod.rs
+++ b/src/backend/openxr/mod.rs
@@ -312,7 +312,7 @@ pub fn openxr_run(running: Arc<AtomicBool>, show_by_default: bool) -> Result<(),
 
         #[cfg(feature = "osc")]
         if let Some(ref mut sender) = app_state.osc_sender {
-            let _ = sender.send_params(&overlays, &app_state);
+            let _ = sender.send_params(&overlays, &app_state.input_state.devices);
         };
 
         let (_, views) = xr_state.session.locate_views(

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -50,7 +50,11 @@ impl OscSender {
         Ok(())
     }
 
-    pub fn send_params<D>(&mut self, overlays: &OverlayContainer<D>, devices: &Vec<TrackedDevice>) -> anyhow::Result<()>
+    pub fn send_params<D>(
+        &mut self,
+        overlays: &OverlayContainer<D>,
+        devices: &Vec<TrackedDevice>,
+    ) -> anyhow::Result<()>
     where
         D: Default,
     {
@@ -93,7 +97,6 @@ impl OscSender {
                 "/avatar/parameters/openOverlayCount".into(),
                 vec![OscType::Int(num_overlays)],
             )?;
-
         }
 
         // send battery levels every 10 seconds
@@ -111,19 +114,19 @@ impl OscSender {
                 // soc is the battery level (set to device status.charge)
                 let level = device.soc.unwrap_or(-1.0);
                 let parameter = match device.role {
-                    TrackedDeviceRole::None =>      {continue}
-                    TrackedDeviceRole::Hmd =>       {
+                    TrackedDeviceRole::None => continue,
+                    TrackedDeviceRole::Hmd => {
                         // legacy OVR Toolkit style (int)
                         // as of 20 Nov 2024 OVR Toolkit uses int 0-100, but this may change in a future update.
                         //TODO: update this once their implementation matches their docs
                         self.send_message(
                             "/avatar/parameters/hmdBattery".into(),
-                                        vec![OscType::Int((level * 100.0f32).round() as i32)],
+                            vec![OscType::Int((level * 100.0f32).round() as i32)],
                         )?;
 
                         "headset"
                     }
-                    TrackedDeviceRole::LeftHand =>  {
+                    TrackedDeviceRole::LeftHand => {
                         controller_count += 1;
                         controller_total_bat += level;
                         "leftController"
@@ -133,7 +136,7 @@ impl OscSender {
                         controller_total_bat += level;
                         "rightController"
                     }
-                    TrackedDeviceRole::Tracker =>   {
+                    TrackedDeviceRole::Tracker => {
                         tracker_count += 1;
                         tracker_total_bat += level;
                         tracker_param = format!("tracker{tracker_count}");
@@ -144,32 +147,37 @@ impl OscSender {
                 // send device battery parameters
                 self.send_message(
                     format!("/avatar/parameters/{parameter}Battery").into(),
-                                vec![OscType::Float(level)],
+                    vec![OscType::Float(level)],
                 )?;
                 self.send_message(
                     format!("/avatar/parameters/{parameter}Charging").into(),
-                                vec![OscType::Bool(device.charging)],
+                    vec![OscType::Bool(device.charging)],
                 )?;
             }
 
             // send average controller and tracker battery parameters
             self.send_message(
                 format!("/avatar/parameters/averageControllerBattery").into(),
-                            vec![OscType::Float(controller_total_bat / controller_count as f32)],
+                vec![OscType::Float(
+                    controller_total_bat / controller_count as f32,
+                )],
             )?;
             self.send_message(
                 format!("/avatar/parameters/averageTrackerBattery").into(),
-                            vec![OscType::Float(tracker_total_bat / tracker_count as f32)],
+                vec![OscType::Float(tracker_total_bat / tracker_count as f32)],
             )?;
         }
 
         Ok(())
     }
 
-    pub fn send_single_param(&mut self, parameter: String, values: Vec<OscType>) -> anyhow::Result<()> {
+    pub fn send_single_param(
+        &mut self,
+        parameter: String,
+        values: Vec<OscType>,
+    ) -> anyhow::Result<()> {
         self.send_message(parameter, values)?;
 
         Ok(())
     }
-
 }

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -13,7 +13,7 @@ use crate::{
     state::AppState,
 };
 
-use super::common::OverlayContainer;
+use super::{common::OverlayContainer, input::TrackedDevice};
 
 pub struct OscSender {
     last_sent_overlay: Instant,
@@ -53,7 +53,7 @@ impl OscSender {
         Ok(())
     }
 
-    pub fn send_params<D>(&mut self, overlays: &OverlayContainer<D>, app: &AppState) -> anyhow::Result<()>
+    pub fn send_params<D>(&mut self, overlays: &OverlayContainer<D>, devices: &Vec<TrackedDevice>) -> anyhow::Result<()>
     where
         D: Default,
     {
@@ -108,7 +108,7 @@ impl OscSender {
             let mut tracker_total_bat = 0.0;
             let mut controller_total_bat = 0.0;
 
-            for device in &app.input_state.devices {
+            for device in devices {
                 let tracker_param;
 
                 // soc is the battery level (set to device status.charge)

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -166,8 +166,8 @@ impl OscSender {
         Ok(())
     }
 
-    pub fn send_single_param(&mut self, parameter: String, value: OscType) -> anyhow::Result<()> {
-        self.send_message(parameter, vec![value])?;
+    pub fn send_single_param(&mut self, parameter: String, values: Vec<OscType>) -> anyhow::Result<()> {
+        self.send_message(parameter, values)?;
 
         Ok(())
     }

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -168,4 +168,9 @@ impl OscSender {
 
         Ok(())
     }
+
+    pub fn send_single_param(&mut self, parameter: String, value: OscType) {
+        self.send_message(parameter, vec![value]);
+    }
+
 }

--- a/src/backend/osc.rs
+++ b/src/backend/osc.rs
@@ -8,10 +8,7 @@ use rosc::{OscMessage, OscPacket, OscType};
 
 use crate::overlays::{keyboard::KEYBOARD_NAME, watch::WATCH_NAME};
 
-use crate::{
-    backend::input::TrackedDeviceRole,
-    state::AppState,
-};
+use crate::backend::input::TrackedDeviceRole;
 
 use super::{common::OverlayContainer, input::TrackedDevice};
 
@@ -169,8 +166,10 @@ impl OscSender {
         Ok(())
     }
 
-    pub fn send_single_param(&mut self, parameter: String, value: OscType) {
-        self.send_message(parameter, vec![value]);
+    pub fn send_single_param(&mut self, parameter: String, value: OscType) -> anyhow::Result<()> {
+        self.send_message(parameter, vec![value])?;
+
+        Ok(())
     }
 
 }

--- a/src/gui/modular/button.rs
+++ b/src/gui/modular/button.rs
@@ -25,7 +25,7 @@ use crate::{
     state::AppState,
 };
 
-#[cfg(not(feature = "wayvr"))]
+#[cfg(any(not(feature = "wayvr"), not(feature = "osc")))]
 use crate::overlays::toast::error_toast_str;
 
 #[cfg(feature = "osc")]
@@ -406,7 +406,8 @@ fn handle_action(action: &ButtonAction, press: &mut PressData, app: &mut AppStat
             };
             #[cfg(not(feature = "osc"))]
             {
-                let _ = &action;
+                let _ = &parameter;
+                let _ = &value;
                 error_toast_str(app, "OSC feature is not enabled");
             }
         }

--- a/src/gui/modular/button.rs
+++ b/src/gui/modular/button.rs
@@ -186,23 +186,23 @@ pub enum ButtonAction {
     SendOscValue {
         parameter: Arc<str>,
         values: Option<Vec<OscValue>>,
-    }
+    },
 }
 
 #[derive(Deserialize, Clone)]
 #[serde(tag = "type")]
 #[cfg(feature = "osc")]
 pub enum OscValue {
-    Int {value: i32},
-    Float {value: f32},
-    String {value: String},
-    Bool {value: bool},
+    Int { value: i32 },
+    Float { value: f32 },
+    String { value: String },
+    Bool { value: bool },
 }
 #[derive(Deserialize, Clone)]
 #[serde(tag = "type")]
 #[cfg(not(feature = "osc"))]
 pub enum OscValue {
-    None
+    None,
 }
 
 pub(super) struct PressData {
@@ -415,7 +415,6 @@ fn handle_action(action: &ButtonAction, press: &mut PressData, app: &mut AppStat
             app.session.config.space_drag_multiplier += delta;
         }
         ButtonAction::SendOscValue { parameter, values } => {
-
             #[cfg(feature = "osc")]
             if let Some(ref mut sender) = app.osc_sender {
                 // convert OscValue to OscType
@@ -423,10 +422,10 @@ fn handle_action(action: &ButtonAction, press: &mut PressData, app: &mut AppStat
 
                 for value in values.as_ref().unwrap() {
                     let converted_value = match value {
-                        OscValue::Bool { value } => {OscType::Bool(*value)},
-                        OscValue::Int { value } => {OscType::Int(*value)},
-                        OscValue::Float { value } => {OscType::Float(*value)},
-                        OscValue::String { value } => {OscType::String(value.to_string())},
+                        OscValue::Bool { value } => OscType::Bool(*value),
+                        OscValue::Int { value } => OscType::Int(*value),
+                        OscValue::Float { value } => OscType::Float(*value),
+                        OscValue::String { value } => OscType::String(value.to_string()),
                     };
 
                     converted.push(converted_value);
@@ -442,8 +441,7 @@ fn handle_action(action: &ButtonAction, press: &mut PressData, app: &mut AppStat
                 let _ = &values;
                 error_toast_str(app, "OSC feature is not enabled");
             }
-        },
- 
+        }
     }
 }
 

--- a/src/gui/modular/button.rs
+++ b/src/gui/modular/button.rs
@@ -29,7 +29,7 @@ use crate::{
 use crate::overlays::toast::error_toast_str;
 
 #[cfg(feature = "osc")]
-use rosc::{OscMessage, OscPacket, OscType};
+use rosc::OscType;
 
 use super::{ExecArgs, ModularControl, ModularData};
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,7 +15,7 @@ use {
 };
 
 use crate::{
-    backend::{input::InputState, overlay::OverlayID, task::TaskContainer},
+    backend::{input::InputState, osc::OscSender, overlay::OverlayID, task::TaskContainer},
     config::{AStrMap, GeneralConfig},
     config_io,
     graphics::WlxGraphics,
@@ -48,6 +48,9 @@ pub struct AppState {
     pub anchor: Affine3A,
     pub sprites: AStrMap<Arc<ImageView>>,
     pub keyboard_focus: KeyboardFocus,
+
+    #[cfg(feature = "osc")]
+    pub osc_sender: Option<OscSender>,
 
     #[cfg(feature = "wayvr")]
     pub wayvr: Option<Rc<RefCell<WayVRData>>>, // Dynamically created if requested
@@ -102,6 +105,10 @@ impl AppState {
             .wayvr_config
             .post_load(&session.config, &mut tasks)?;
 
+        #[cfg(feature = "osc")]
+        let osc_sender = 
+            crate::backend::osc::OscSender::new(session.config.osc_out_port).ok();
+
         Ok(AppState {
             fc: FontCache::new(session.config.primary_font.clone())?,
             session,
@@ -114,6 +121,9 @@ impl AppState {
             anchor: Affine3A::IDENTITY,
             sprites: AStrMap::new(),
             keyboard_focus: KeyboardFocus::PhysicalScreen,
+
+            #[cfg(feature = "osc")]
+            osc_sender,
 
             #[cfg(feature = "wayvr")]
             wayvr,

--- a/src/state.rs
+++ b/src/state.rs
@@ -109,8 +109,7 @@ impl AppState {
             .post_load(&session.config, &mut tasks)?;
 
         #[cfg(feature = "osc")]
-        let osc_sender = 
-            crate::backend::osc::OscSender::new(session.config.osc_out_port).ok();
+        let osc_sender = crate::backend::osc::OscSender::new(session.config.osc_out_port).ok();
 
         Ok(AppState {
             fc: FontCache::new(session.config.primary_font.clone())?,

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,8 +14,11 @@ use {
     std::{cell::RefCell, rc::Rc},
 };
 
+#[cfg(feature = "osc")]
+use crate::backend::osc::OscSender;
+
 use crate::{
-    backend::{input::InputState, osc::OscSender, overlay::OverlayID, task::TaskContainer},
+    backend::{input::InputState, overlay::OverlayID, task::TaskContainer},
     config::{AStrMap, GeneralConfig},
     config_io,
     graphics::WlxGraphics,


### PR DESCRIPTION
Just adds an action to buttons that sends a Float to an address over OSC. (e.g. to control a VRChat avatar, or some other OSC application)

I've just implemented it with `OscType::Float` for now since it can represent Float, Int, and Bool. (at least for VRChat)
Unsure if making separate actions for each type or trying to handle the type internally somehow (`type: float` or `float_value: 3.5`) is better. (in draft for feedback)

```
# button press example
click_down:
  - type: SendOSCFloat
    parameter: "/avatar/parameters/button1"
    value: 1
click_up:
  - type: SendOSCFloat
    parameter: "/avatar/parameters/button1"
    value: 0
```

It also merges the OSC client creation from openxr.rs and openvr.rs into state.rs `state.app`, and makes osc.rs `send_params()` take in a list of devices instead of `app_state` itself, since I was having borrow issues calling `app.sender.send_params(overlays, app)` (approximately).

Small note, setting a bool to 0 works as False, and setting it to 1 shows up as True in VRChat's OSC debug panel, but my avatar doesn't react to the True state. Not sure if I broke something on my avatar, or what. Needs some more testing.

Would also need to update documentation here:
https://github.com/galister/wlx-overlay-s/wiki/Customize-UI#button-actions