### PR TITLE
WayVR: Improvements (WayVR Dash 0.1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "wayvr_ipc"
 version = "0.1.0"
-source = "git+https://github.com/olekolek1000/wayvr-ipc.git?rev=94ab6125ec07c091099bf71b028d701b58eccccf#94ab6125ec07c091099bf71b028d701b58eccccf"
+source = "git+https://github.com/olekolek1000/wayvr-ipc.git?rev=fe2e8be04c7b86adcf972be7ebe46961bd881f35#fe2e8be04c7b86adcf972be7ebe46961bd881f35"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ wayland-client = { version = "0.31.6", optional = true }
 wayland-egl = { version = "0.32.4", optional = true }
 interprocess = { version = "2.2.2", optional = true }
 bytes = { version = "1.9.0", optional = true }
-wayvr_ipc = { git = "https://github.com/olekolek1000/wayvr-ipc.git", rev = "94ab6125ec07c091099bf71b028d701b58eccccf", default-features = false, optional = true }
+wayvr_ipc = { git = "https://github.com/olekolek1000/wayvr-ipc.git", rev = "fe2e8be04c7b86adcf972be7ebe46961bd881f35", default-features = false, optional = true }
 ################################
 
 [build-dependencies]

--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -241,6 +241,7 @@ pub struct PointerHit {
     pub dist: f32,
 }
 
+#[derive(Clone)]
 pub struct Haptics {
     pub intensity: f32,
     pub duration: f32,

--- a/src/backend/openxr/lines.rs
+++ b/src/backend/openxr/lines.rs
@@ -135,7 +135,7 @@ impl LinePool {
         &'a mut self,
         xr: &'a XrState,
         command_buffer: &mut WlxCommandBuffer,
-    ) -> anyhow::Result<Vec<CompositionLayer>> {
+    ) -> anyhow::Result<Vec<CompositionLayer<'a>>> {
         let mut quads = Vec::new();
 
         for line in self.lines.values_mut() {

--- a/src/backend/openxr/overlay.rs
+++ b/src/backend/openxr/overlay.rs
@@ -27,7 +27,7 @@ impl OverlayData<OpenXrOverlayData> {
         &'a mut self,
         xr: &'a XrState,
         command_buffer: &mut WlxCommandBuffer,
-    ) -> anyhow::Result<CompositionLayer> {
+    ) -> anyhow::Result<CompositionLayer<'a>> {
         if let Some(new_view) = self.view() {
             self.data.last_view = Some(new_view);
         }

--- a/src/backend/openxr/skybox.rs
+++ b/src/backend/openxr/skybox.rs
@@ -74,7 +74,7 @@ impl Skybox {
         xr: &'a XrState,
         hmd: Affine3A,
         command_buffer: &mut WlxCommandBuffer,
-    ) -> anyhow::Result<Vec<CompositionLayer>> {
+    ) -> anyhow::Result<Vec<CompositionLayer<'a>>> {
         let (sky_image, grid_image) = if let Some((ref mut srd_sky, ref mut srd_grid)) = self.srd {
             (srd_sky.present_last()?, srd_grid.present_last()?)
         } else {

--- a/src/backend/overlay.rs
+++ b/src/backend/overlay.rs
@@ -32,7 +32,8 @@ pub const Z_ORDER_TOAST: u32 = 70;
 pub const Z_ORDER_LINES: u32 = 69;
 pub const Z_ORDER_WATCH: u32 = 68;
 pub const Z_ORDER_ANCHOR: u32 = 67;
-pub const Z_ORDER_DASHBOARD: u32 = 66;
+pub const Z_ORDER_DEFAULT: u32 = 0;
+pub const Z_ORDER_DASHBOARD: u32 = Z_ORDER_DEFAULT;
 
 pub struct OverlayState {
     pub id: OverlayID,
@@ -73,7 +74,7 @@ impl Default for OverlayState {
             keyboard_focus: None,
             dirty: true,
             alpha: 1.0,
-            z_order: 0,
+            z_order: Z_ORDER_DEFAULT,
             relative_to: RelativeTo::None,
             curvature: None,
             spawn_scale: 1.0,

--- a/src/backend/wayvr/display.rs
+++ b/src/backend/wayvr/display.rs
@@ -124,7 +124,7 @@ impl Display {
             )
         })?;
 
-        let egl_image = egl_data.create_egl_image(tex_id, width as u32, height as u32)?;
+        let egl_image = egl_data.create_egl_image(tex_id)?;
         let dmabuf_data = egl_data.create_dmabuf_data(&egl_image)?;
 
         let opaque = false;
@@ -207,7 +207,8 @@ impl Display {
             } else if let Some(auto_hide_delay) = config.auto_hide_delay {
                 if let Some(s) = self.no_windows_since {
                     if s + (auto_hide_delay as u64) < get_millis() {
-                        signals.send(WayVRSignal::DisplayHideRequest(*handle));
+                        // Auto-hide after specific time
+                        signals.send(WayVRSignal::DisplayVisibility(*handle, false));
                     }
                 }
             }

--- a/src/backend/wayvr/egl_data.rs
+++ b/src/backend/wayvr/egl_data.rs
@@ -45,7 +45,9 @@ impl EGLData {
 
             let display = egl
                 .get_display(khronos_egl::DEFAULT_DISPLAY)
-                .ok_or(anyhow!("eglGetDisplay failed"))?;
+                .ok_or(anyhow!(
+                    "eglGetDisplay failed. This shouldn't happen unless you don't have any display manager running. Cannot continue, check your EGL installation."
+                ))?;
 
             let (major, minor) = egl.initialize(display)?;
             log::debug!("EGL version: {}.{}", major, minor);
@@ -242,25 +244,14 @@ impl EGLData {
         }
     }
 
-    pub fn create_egl_image(
-        &self,
-        gl_tex_id: u32,
-        width: u32,
-        height: u32,
-    ) -> anyhow::Result<khronos_egl::Image> {
+    pub fn create_egl_image(&self, gl_tex_id: u32) -> anyhow::Result<khronos_egl::Image> {
         unsafe {
             Ok(self.egl.create_image(
                 self.display,
                 self.context,
                 khronos_egl::GL_TEXTURE_2D as std::ffi::c_uint,
                 khronos_egl::ClientBuffer::from_ptr(gl_tex_id as *mut std::ffi::c_void),
-                &[
-                    khronos_egl::WIDTH as usize,
-                    width as usize,
-                    khronos_egl::HEIGHT as usize,
-                    height as usize,
-                    khronos_egl::ATTRIB_NONE,
-                ],
+                &[khronos_egl::ATTRIB_NONE],
             )?)
         }
     }


### PR DESCRIPTION
Wlx:
```
- Fix compilation warnings
```

WayVR:
```
- IPC: Add `WvrDisplaySetVisible` and `WlxHaptics`
- Do not pass width and height to `eglCreateImage`
- Set dashboard larger and further a bit
- Bump dashboard resolution from 960x540 to 1920x1080
```

WayVR Dashboard (version 0.1.1):
```
- Haptics feedback on button enter and down/up
- Hide created display by default
- Automatically show hidden display after spawning a process
- DisplayOptions: "Show"/"Hide" button
- DisplayList: Refresh display list directly after changing its state
- Auto-scale content to window size (16:9, centered). 100% resolution at 960x540.
- Exclude `wayvr_dashboard` from the process list, probably nobody wants to close it permanently
```