### PR TITLE
Add NvFBC support for X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5286,7 +5286,8 @@ dependencies = [
 
 [[package]]
 name = "wlx-capture"
-version = "0.5.3"
+version = "0.5.4"
+source = "git+https://github.com/cheesecakecg/wlx-capture?branch=nvfbc-support#1f033b01265044b3f348986fb2eabd45034c8c3e"
 dependencies = [
  "ashpd",
  "drm-fourcc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,6 +2713,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvfbc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b339b5c554c55904a032ec03598191071b8fbead3b89a8aabc2465727803ecc2"
+dependencies = [
+ "nvfbc-sys",
+]
+
+[[package]]
+name = "nvfbc-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1312c329848acc8f07a288dac9ba67edddae2c222a018916c01e47dad1f14d5b"
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,14 +5286,15 @@ dependencies = [
 
 [[package]]
 name = "wlx-capture"
-version = "0.5.4"
-source = "git+https://github.com/galister/wlx-capture?tag=v0.5.4#1aad584fafd529c63cce3355f0b2e2175ab69c70"
+version = "0.5.3"
 dependencies = [
  "ashpd",
  "drm-fourcc",
  "idmap",
  "libc",
  "log",
+ "nvfbc",
+ "once_cell",
  "pipewire",
  "rxscreen",
  "smithay-client-toolkit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5286,8 +5286,8 @@ dependencies = [
 
 [[package]]
 name = "wlx-capture"
-version = "0.5.4"
-source = "git+https://github.com/cheesecakecg/wlx-capture?branch=nvfbc-support#1f033b01265044b3f348986fb2eabd45034c8c3e"
+version = "0.5.3"
+source = "git+https://github.com/cheesecakecg/wlx-capture?branch=nvfbc-support#f3119c5669b0aa8b66a334c5c04cfa0f5d1ca532"
 dependencies = [
  "ashpd",
  "drm-fourcc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,15 @@ license = "GPL-3.0-only"
 authors = ["galister"]
 description = "Access your Wayland/X11 desktop from Monado/WiVRn/SteamVR. Now with Vulkan!"
 repository = "https://github.com/galister/wlx-overlay-s"
-keywords = ["linux", "openvr", "openxr", "x11", "wayland", "openvr-overlay", "openxr-overlay"]
+keywords = [
+  "linux",
+  "openvr",
+  "openxr",
+  "x11",
+  "wayland",
+  "openvr-overlay",
+  "openxr-overlay",
+]
 categories = ["games"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -58,7 +66,7 @@ sysinfo = { version = "0.34.2" }
 thiserror = "2.0.3"
 vulkano = { version = "0.35.1" }
 vulkano-shaders = { version = "0.35.0" }
-wlx-capture = { git = "https://github.com/galister/wlx-capture", tag = "v0.5.4", default-features = false }
+wlx-capture = { path = "/home/chrisd/Sync/FOSS/wlx-capture/", default-features = false }
 libmonado = { version = "1.3.2", optional = true }
 winit = { version = "0.30.0", optional = true }
 xdg = "2.5.2"
@@ -98,11 +106,12 @@ wayvr_ipc = { git = "https://github.com/olekolek1000/wayvr-ipc.git", rev = "a725
 regex = { version = "1.11.1" }
 
 [features]
-default = ["openvr", "openxr", "osc", "x11", "wayland", "wayvr"]
+default = ["openvr", "openxr", "osc", "x11", "wayland", "wayvr", "nvfbc"]
 openvr = ["dep:ovr_overlay", "dep:json"]
 openxr = ["dep:openxr", "dep:libmonado"]
 osc = ["dep:rosc"]
 x11 = ["dep:xcb", "wlx-capture/xshm", "xkbcommon/x11"]
+nvfbc = ["wlx-capture/nvfbc"]
 wayland = ["pipewire", "wlx-capture/wlr", "xkbcommon/wayland"]
 pipewire = ["wlx-capture/pipewire"]
 uidev = ["dep:winit"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ sysinfo = { version = "0.34.2" }
 thiserror = "2.0.3"
 vulkano = { version = "0.35.1" }
 vulkano-shaders = { version = "0.35.0" }
-wlx-capture = { path = "/home/chrisd/Sync/FOSS/wlx-capture/", default-features = false }
+wlx-capture = { git = "https://github.com/cheesecakecg/wlx-capture", default-features = false, branch = "nvfbc-support" }
 libmonado = { version = "1.3.2", optional = true }
 winit = { version = "0.30.0", optional = true }
 xdg = "2.5.2"

--- a/src/backend/common.rs
+++ b/src/backend/common.rs
@@ -87,7 +87,13 @@ where
                     Ok(data) => data,
                     Err(e) => {
                         log::info!("Will not use X11 PipeWire capture: {e:?}");
-                        crate::overlays::screen::create_screens_xshm(app)?
+                        match crate::overlays::screen::create_screens_nvfbc(app) {
+                            Ok(data) => data,
+                            Err(e) => {
+                                log::info!("Will not use NvFBC capture: {:?}", e);
+                                crate::overlays::screen::create_screens_xshm(app)?
+                            }
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Depends on https://github.com/galister/wlx-capture/pull/4

The NvFBC wrapper package doesn't _seem_ to support capturing from other monitors besides the first one, but I think I must be doing something wrong. This PR doesn't properly check which monitor the image is for, and I haven't tested it with multiple monitors plugged in to know what happens when if you try.