### PR TITLE
Add default space_reset binding for all controllers

### DIFF
--- a/src/backend/openxr/openxr_actions.json5
+++ b/src/backend/openxr/openxr_actions.json5
@@ -138,10 +138,10 @@
       left: "/user/hand/left/input/thumbstick/x",
       right: "/user/hand/right/input/thumbstick/x"
     },
-		toggle_dashboard: {
-			double_click: false,
-			right: "/user/hand/right/input/system/click",
-		},
+    toggle_dashboard: {
+      double_click: false,
+      right: "/user/hand/right/input/system/click",
+    },
     show_hide: {
       double_click: true,
       left: "/user/hand/left/input/b/click",

--- a/src/backend/openxr/openxr_actions.json5
+++ b/src/backend/openxr/openxr_actions.json5
@@ -158,10 +158,6 @@
       left: "/user/hand/left/input/trackpad/force",
       double_click: true,
     },
-    space_reset: {
-      double_click: true,
-      left: "/user/hand/left/input/trackpad/force",
-    },
     click_modifier_right: {
       left: "/user/hand/left/input/b/touch",
       right: "/user/hand/right/input/b/touch"
@@ -210,7 +206,6 @@
       double_click: true,
       right: "/user/hand/right/input/menu/click",
     },
-    space_reset: {
     haptic: {
       left: "/user/hand/left/output/haptic",
       right: "/user/hand/right/output/haptic"

--- a/src/backend/openxr/openxr_actions.json5
+++ b/src/backend/openxr/openxr_actions.json5
@@ -92,6 +92,10 @@
     space_drag: {
       left: "/user/hand/left/input/menu/click",
     },
+    space_reset: {
+      double_click: true,
+      left: "/user/hand/left/input/menu/click",
+    },
     click_modifier_right: {
       left: "/user/hand/left/input/y/touch",
       right: "/user/hand/right/input/b/touch"
@@ -151,6 +155,10 @@
       // right trackpad is alt_click
     },
     space_reset: {
+      left: "/user/hand/left/input/trackpad/force",
+      double_click: true,
+    },
+    space_reset: {
       double_click: true,
       left: "/user/hand/left/input/trackpad/force",
     },
@@ -198,6 +206,11 @@
     space_drag: {
       right: "/user/hand/right/input/menu/click",
     },
+    space_reset: {
+      double_click: true,
+      right: "/user/hand/right/input/menu/click",
+    },
+    space_reset: {
     haptic: {
       left: "/user/hand/left/output/haptic",
       right: "/user/hand/right/output/haptic"
@@ -237,6 +250,10 @@
     space_drag: {
       right: "/user/hand/right/input/menu/click",
     },
+    space_reset: {
+      double_click: true,
+      right: "/user/hand/right/input/menu/click",
+    },
   },
 
   // HP Reverb G2 controller
@@ -270,6 +287,10 @@
       left: "/user/hand/left/input/menu/click",
     },
     space_drag: {
+      right: "/user/hand/right/input/menu/click",
+    },
+    space_reset: {
+      double_click: true,
       right: "/user/hand/right/input/menu/click",
     },
   },


### PR DESCRIPTION
Currently, only the Index controllers have a space_reset binding by default, bound to the space_drag binding's double click
I've copied that same logic over to all controllers so that all controllers have a default space_reset binding