### PR TITLE
WayVR: Update wayvr.yaml

### DIFF
--- a/src/res/wayvr.yaml
+++ b/src/res/wayvr.yaml
@@ -37,12 +37,10 @@ keyboard_repeat_rate: 50
 #
 # exec: Executable path, for example "/home/USER/wayvr-dashboard/src-tauri/target/release/wayvr-dashboard"
 # or just "wayvr-dashboard" if you have it installed from your package manager.
-#
-# GDK_BACKEND=wayland: Force-use Wayland for GTK apps.
 dashboard:
   exec: "wayvr-dashboard"
   args: ""
-  env: ["GDK_BACKEND=wayland"]
+  env: []
 
 displays:
   watch:


### PR DESCRIPTION
WayVR Dashboard doesn't need this environment variable anymore since version 0.3.3, it's set automatically.

[skip ci]