### PR TITLE
Improve default WMR OpenXR bindings

### DIFF
--- a/src/backend/openxr/helpers.rs
+++ b/src/backend/openxr/helpers.rs
@@ -37,11 +37,18 @@ pub(super) fn init_xr() -> Result<(xr::Instance, xr::SystemId), anyhow::Error> {
     } else {
         log::warn!("Missing EXT_composition_layer_cylinder extension.");
     }
-
     if available_extensions.khr_composition_layer_equirect2 {
         enabled_extensions.khr_composition_layer_equirect2 = true;
     } else {
         log::warn!("Missing EXT_composition_layer_equirect2 extension.");
+    }
+    if available_extensions
+        .other
+        .contains(&"XR_MNDX_system_buttons".to_owned())
+    {
+        enabled_extensions
+            .other
+            .push("XR_MNDX_system_buttons".to_owned());
     }
 
     //#[cfg(not(debug_assertions))]

--- a/src/backend/openxr/input.rs
+++ b/src/backend/openxr/input.rs
@@ -453,7 +453,7 @@ fn is_bool(maybe_type_str: Option<&String>) -> bool {
         .unwrap() // want panic
         .split('/')
         .next_back()
-        .is_some_and(|last| matches!(last, "click" | "touch"))
+        .is_some_and(|last| matches!(last, "click" | "touch") || last.starts_with("dpad_"))
 }
 
 macro_rules! add_custom {

--- a/src/backend/openxr/openxr_actions.json5
+++ b/src/backend/openxr/openxr_actions.json5
@@ -249,6 +249,14 @@
       double_click: true,
       right: "/user/hand/right/input/menu/click",
     },
+    click_modifier_right: {
+      left: "/user/hand/left/input/trackpad/dpad_up",
+      right: "/user/hand/right/input/trackpad/dpad_up"
+    },
+    click_modifier_middle: {
+      left: "/user/hand/left/input/trackpad/dpad_down",
+      right: "/user/hand/right/input/trackpad/dpad_down"
+    },
   },
 
   // HP Reverb G2 controller

--- a/src/backend/openxr/openxr_actions.json5
+++ b/src/backend/openxr/openxr_actions.json5
@@ -240,14 +240,14 @@
       right: "/user/hand/right/input/thumbstick/x"
     },
     show_hide: {
-      left: "/user/hand/left/input/menu/click",
+      left: "/user/hand/left/input/system/click",
     },
     space_drag: {
-      right: "/user/hand/right/input/menu/click",
+      right: "/user/hand/right/input/system/click",
     },
     space_reset: {
       double_click: true,
-      right: "/user/hand/right/input/menu/click",
+      right: "/user/hand/right/input/system/click",
     },
     click_modifier_right: {
       left: "/user/hand/left/input/trackpad/dpad_up",
@@ -287,14 +287,14 @@
       right: "/user/hand/right/input/thumbstick/x"
     },
     show_hide: {
-      left: "/user/hand/left/input/menu/click",
+      left: "/user/hand/left/input/system/click",
     },
     space_drag: {
-      right: "/user/hand/right/input/menu/click",
+      right: "/user/hand/right/input/system/click",
     },
     space_reset: {
       double_click: true,
-      right: "/user/hand/right/input/menu/click",
+      right: "/user/hand/right/input/system/click",
     },
   },
 


### PR DESCRIPTION
This PR restores the old default dpad bindings for click modifiers (dpad up for right click and dpad down middle click). Those bindings were removed in commit b8a0e36. 
This PR also binds the show_hide, space_drag, and space_rest actions to the system buttons, which doesn't interfere with the menu bindings in most games.

The OpenXR dpad binding extension is currently broken in upstream Monado, I'm looking into this.

The OpenXR dpad binding extension only allows binding to touchpad clicks and not to trackpad touches, so this conflicts more often with other applications than the default Quest bindings. I still think having these buttons work is better than not having them at all.


