### PR TITLE
Add X-WiVRn-VR category in .desktop file

### DIFF
--- a/wlx-overlay-s.desktop
+++ b/wlx-overlay-s.desktop
@@ -4,4 +4,4 @@ Name=WlxOverlay-S
 Exec=wlx-overlay-s
 Icon=wlx-overlay-s
 Terminal=true
-Categories=Utility;
+Categories=Utility;X-WiVRn-VR;


### PR DESCRIPTION
WiVRn now parses .desktop files and uses the X-WiVRn-VR category to filter applications it should show.