### PR TITLE
[Feature] Add left-handed mouse emulation for swapped button handling

### DIFF
--- a/left_handed_config.yaml
+++ b/left_handed_config.yaml
@@ -1,0 +1,7 @@
+# WlxOverlay-S configuration for left-handed mouse mode
+# Place this file in ~/.config/wlxoverlay/conf.d/left_handed.yaml
+
+# Enable left-handed mouse mode
+# This swaps the left and right mouse buttons to compensate for
+# system-level left-handed mouse configuration in KDE/GNOME/etc.
+left_handed_mouse: true

--- a/left_handed_config.yaml
+++ b/left_handed_config.yaml
@@ -1,7 +1,0 @@
-# WlxOverlay-S configuration for left-handed mouse mode
-# Place this file in ~/.config/wlxoverlay/conf.d/left_handed.yaml
-
-# Enable left-handed mouse mode
-# This swaps the left and right mouse buttons to compensate for
-# system-level left-handed mouse configuration in KDE/GNOME/etc.
-left_handed_mouse: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,6 +274,9 @@ pub struct GeneralConfig {
     pub focus_follows_mouse_mode: bool,
 
     #[serde(default = "def_false")]
+    pub left_handed_mouse: bool,
+
+    #[serde(default = "def_false")]
     pub block_game_input: bool,
 
     #[serde(default = "def_true")]

--- a/src/overlays/screen.rs
+++ b/src/overlays/screen.rs
@@ -134,6 +134,17 @@ impl InteractionHandler for ScreenInteractionHandler {
             _ => MOUSE_LEFT,
         };
 
+        // Swap left and right buttons if left-handed mode is enabled
+        let btn = if app.session.config.left_handed_mouse {
+            match btn {
+                MOUSE_LEFT => MOUSE_RIGHT,
+                MOUSE_RIGHT => MOUSE_LEFT,
+                other => other,
+            }
+        } else {
+            btn
+        };
+
         if pressed {
             set_next_move(u64::from(app.session.config.click_freeze_time_ms));
         }


### PR DESCRIPTION
### Description

This PR introduces a configurable option for left-handed mouse emulation to handle cases where system-wide button swapping causes VR controller inputs to register incorrectly: left clicks being detected as right clicks and vice versa.

### Changes

Added a new boolean config option left_handed_mouse (default: false) in `src/config.rs`.
Updated `src/overlays/screen.rs` to swap MOUSE_LEFT and MOUSE_RIGHT button handling when the option is enabled.

Closes #248 