### PR TITLE
Configurable screen names

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -178,6 +178,10 @@ const fn def_max_height() -> u16 {
     1440
 }
 
+const fn def_screen_names() -> AStrMap<String> {
+    AStrMap::new()
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct GeneralConfig {
     #[serde(default = "def_watch_pos")]
@@ -314,6 +318,9 @@ pub struct GeneralConfig {
 
     #[serde(default = "def_timezones")]
     pub timezones: Vec<String>,
+
+    #[serde(default = "def_screen_names")]
+    pub screen_names: AStrMap<String>,
 }
 
 impl GeneralConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -178,7 +178,7 @@ const fn def_max_height() -> u16 {
     1440
 }
 
-const fn def_screen_names() -> AStrMap<String> {
+const fn def_screen_names() -> AStrMap<Arc<str>> {
     AStrMap::new()
 }
 
@@ -320,7 +320,7 @@ pub struct GeneralConfig {
     pub timezones: Vec<String>,
 
     #[serde(default = "def_screen_names")]
-    pub screen_names: AStrMap<String>,
+    pub screen_names: AStrMap<Arc<str>>,
 }
 
 impl GeneralConfig {

--- a/src/gui/modular/mod.rs
+++ b/src/gui/modular/mod.rs
@@ -334,7 +334,7 @@ pub fn modular_canvas(
                         button_w - 4.,
                         button_h - 4.,
                         corner_radius.unwrap_or_default(),
-                        screen.name.clone(),
+                        state.try_get_screen_name(screen.name.clone()),
                     );
 
                     // cursed

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,7 @@ use crate::backend::osc::OscSender;
 
 use crate::{
     backend::{input::InputState, overlay::OverlayID, task::TaskContainer},
-    config::{AStrMap, GeneralConfig},
+    config::{AStrMap, AStrMapExt, GeneralConfig},
     config_io,
     graphics::WlxGraphics,
     gui::font::FontCache,
@@ -179,6 +179,14 @@ impl AppState {
                 log::warn!("{e:?}");
                 fallback_data
             }
+        }
+    }
+
+    pub fn try_get_screen_name(&self, screen: Arc<str>) -> Arc<str>
+    {
+        return match self.session.config.screen_names.arc_get(screen.as_ref()) {
+            Some(n) => n.to_owned(),
+            None => screen,
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -182,12 +182,11 @@ impl AppState {
         }
     }
 
-    pub fn try_get_screen_name(&self, screen: Arc<str>) -> Arc<str>
-    {
+    pub fn try_get_screen_name(&self, screen: Arc<str>) -> Arc<str> {
         return match self.session.config.screen_names.arc_get(screen.as_ref()) {
             Some(n) => n.to_owned(),
             None => screen,
-        }
+        };
     }
 }
 


### PR DESCRIPTION
Adds an entry to the config file to specify overrides for screen names based on the "default" name provided to Wlx.

Assign based on the labels shown in the watch, so use `HDMI-A-1` or `DP-1` or `Screen 1`, etc.

My config would go like this, named after the random assortment of monitors I have:
```yaml
# ~/.config/wlxoverlay/conf.d/screen_names.yaml
screen_names:
- - DP-2
  - Dell
- - DP-3
  - Asus
- - HDMI-A-1
  - Philips
```

Only tested on `wayland`.