### PR TITLE
attribs rework

### DIFF
--- a/uidev/src/testbed/testbed_generic.rs
+++ b/uidev/src/testbed/testbed_generic.rs
@@ -7,9 +7,9 @@ use crate::{
 use glam::Vec2;
 use wgui::{
 	components::{
-		Component,
 		button::{ButtonClickCallback, ComponentButton},
 		checkbox::ComponentCheckbox,
+		Component,
 	},
 	drawing::Color,
 	event::EventListenerCollection,
@@ -66,17 +66,17 @@ impl TestbedGeneric {
 
 		let extra = ParseDocumentExtra {
 			on_custom_attribs: Some(Box::new(move |par| {
-				let Some(my_custom_value) = par.get_value("my_custom") else {
+				let Some(my_custom_value) = par.get_value("_my_custom") else {
 					return;
 				};
 
-				let Some(mult_value) = par.get_value("mult") else {
+				let Some(mult_value) = par.get_value("_mult") else {
 					return;
 				};
 
 				let mult_f32 = mult_value.parse::<f32>().unwrap();
 
-				let mut color = match my_custom_value {
+				let mut color = match my_custom_value.as_ref() {
 					"red" => Color::new(1.0, 0.0, 0.0, 1.0),
 					"green" => Color::new(0.0, 1.0, 0.0, 1.0),
 					"blue" => Color::new(0.0, 0.0, 1.0, 1.0),

--- a/wgui/doc/widgets.md
+++ b/wgui/doc/widgets.md
@@ -100,6 +100,16 @@ _Text size in pixel units_
 
 `weight`: "normal" | "bold"
 
+`shadow`: #112233 | #112233CC (default: None)
+
+`shadow_x`: **float** (default: 1.5)
+
+_Horizontal offset of the shadow from the original text. Positive is right._
+
+`shadow_y`: **float** (default: 1.5)
+
+_Vertical offset of the shadow from the original text. Positive is down._
+
 ---
 
 ## rectangle widget

--- a/wgui/src/drawing.rs
+++ b/wgui/src/drawing.rs
@@ -7,7 +7,7 @@ use taffy::TraversePartialTree;
 use crate::{
 	drawing,
 	layout::Widget,
-	renderer_vk::text::custom_glyph::CustomGlyph,
+	renderer_vk::text::{custom_glyph::CustomGlyph, TextShadow},
 	stack::{self, ScissorStack, TransformStack},
 	widget::{self},
 };
@@ -135,7 +135,7 @@ pub struct PrimitiveExtent {
 
 pub enum RenderPrimitive {
 	Rectangle(PrimitiveExtent, Rectangle),
-	Text(PrimitiveExtent, Rc<RefCell<Buffer>>),
+	Text(PrimitiveExtent, Rc<RefCell<Buffer>>, Option<TextShadow>),
 	Sprite(PrimitiveExtent, Option<CustomGlyph>), //option because we want as_slice
 	ScissorEnable(Boundary),
 	ScissorDisable,

--- a/wgui/src/parser/component_button.rs
+++ b/wgui/src/parser/component_button.rs
@@ -1,11 +1,12 @@
 use crate::{
-	components::{Component, button},
+	components::{button, Component},
 	drawing::Color,
 	i18n::Translation,
 	layout::WidgetID,
 	parser::{
-		ParserContext, ParserFile, iter_attribs, parse_children, process_component,
+		parse_children, process_component,
 		style::{parse_color_opt, parse_round, parse_style, parse_text_style},
+		AttribPair, ParserContext, ParserFile,
 	},
 	widget::util::WLength,
 };
@@ -15,6 +16,7 @@ pub fn parse_component_button<'a, U1, U2>(
 	ctx: &mut ParserContext<U1, U2>,
 	node: roxmltree::Node<'a, 'a>,
 	parent_id: WidgetID,
+	attribs: &[AttribPair],
 ) -> anyhow::Result<WidgetID> {
 	let mut color: Option<Color> = None;
 	let mut border_color: Option<Color> = None;
@@ -23,11 +25,11 @@ pub fn parse_component_button<'a, U1, U2>(
 	let mut round = WLength::Units(4.0);
 	let mut translation: Option<Translation> = None;
 
-	let attribs: Vec<_> = iter_attribs(file, ctx, &node, false).collect();
-	let text_style = parse_text_style(&attribs);
-	let style = parse_style(&attribs);
+	let text_style = parse_text_style(attribs);
+	let style = parse_style(attribs);
 
-	for (key, value) in attribs {
+	for pair in attribs {
+		let (key, value) = (pair.attrib.as_ref(), pair.value.as_ref());
 		match key.as_ref() {
 			"text" => {
 				translation = Some(Translation::from_raw_text(&value));
@@ -73,7 +75,7 @@ pub fn parse_component_button<'a, U1, U2>(
 		},
 	)?;
 
-	process_component(file, ctx, node, Component(component), new_id);
+	process_component(ctx, Component(component), new_id, attribs);
 	parse_children(file, ctx, node, new_id)?;
 
 	Ok(new_id)

--- a/wgui/src/parser/component_checkbox.rs
+++ b/wgui/src/parser/component_checkbox.rs
@@ -1,38 +1,35 @@
 use crate::{
-	components::{Component, checkbox},
+	components::{checkbox, Component},
 	i18n::Translation,
 	layout::WidgetID,
-	parser::{
-		ParserContext, ParserFile, iter_attribs, parse_check_f32, parse_check_i32, process_component, style::parse_style,
-	},
+	parser::{parse_check_f32, parse_check_i32, process_component, style::parse_style, AttribPair, ParserContext},
 };
 
 pub fn parse_component_checkbox<'a, U1, U2>(
-	file: &'a ParserFile,
 	ctx: &mut ParserContext<U1, U2>,
-	node: roxmltree::Node<'a, 'a>,
 	parent_id: WidgetID,
+	attribs: &[AttribPair],
 ) -> anyhow::Result<WidgetID> {
 	let mut box_size = 24.0;
 	let mut translation = Translation::default();
 	let mut checked = 0;
 
-	let attribs: Vec<_> = iter_attribs(file, ctx, &node, false).collect();
-	let style = parse_style(&attribs);
+	let style = parse_style(attribs);
 
-	for (key, value) in attribs {
-		match key.as_ref() {
+	for pair in attribs {
+		let (key, value) = (pair.attrib.as_ref(), pair.value.as_ref());
+		match key {
 			"text" => {
-				translation = Translation::from_raw_text(&value);
+				translation = Translation::from_raw_text(value);
 			}
 			"translation" => {
-				translation = Translation::from_translation_key(&value);
+				translation = Translation::from_translation_key(value);
 			}
 			"box_size" => {
-				parse_check_f32(value.as_ref(), &mut box_size);
+				parse_check_f32(value, &mut box_size);
 			}
 			"checked" => {
-				parse_check_i32(value.as_ref(), &mut checked);
+				parse_check_i32(value, &mut checked);
 			}
 			_ => {}
 		}
@@ -50,7 +47,7 @@ pub fn parse_component_checkbox<'a, U1, U2>(
 		},
 	)?;
 
-	process_component(file, ctx, node, Component(component), new_id);
+	process_component(ctx, Component(component), new_id, attribs);
 
 	Ok(new_id)
 }

--- a/wgui/src/parser/component_slider.rs
+++ b/wgui/src/parser/component_slider.rs
@@ -1,32 +1,31 @@
 use crate::{
-	components::{Component, slider},
+	components::{slider, Component},
 	layout::WidgetID,
-	parser::{ParserContext, ParserFile, iter_attribs, parse_check_f32, process_component, style::parse_style},
+	parser::{parse_check_f32, process_component, style::parse_style, AttribPair, ParserContext},
 };
 
 pub fn parse_component_slider<'a, U1, U2>(
-	file: &'a ParserFile,
 	ctx: &mut ParserContext<U1, U2>,
-	node: roxmltree::Node<'a, 'a>,
 	parent_id: WidgetID,
+	attribs: &[AttribPair],
 ) -> anyhow::Result<WidgetID> {
 	let mut min_value = 0.0;
 	let mut max_value = 1.0;
 	let mut initial_value = 0.5;
 
-	let attribs: Vec<_> = iter_attribs(file, ctx, &node, false).collect();
-	let style = parse_style(&attribs);
+	let style = parse_style(attribs);
 
-	for (key, value) in attribs {
-		match key.as_ref() {
+	for pair in attribs {
+		let (key, value) = (pair.attrib.as_ref(), pair.value.as_ref());
+		match key {
 			"min_value" => {
-				parse_check_f32(value.as_ref(), &mut min_value);
+				parse_check_f32(value, &mut min_value);
 			}
 			"max_value" => {
-				parse_check_f32(value.as_ref(), &mut max_value);
+				parse_check_f32(value, &mut max_value);
 			}
 			"value" => {
-				parse_check_f32(value.as_ref(), &mut initial_value);
+				parse_check_f32(value, &mut initial_value);
 			}
 			_ => {}
 		}
@@ -46,7 +45,7 @@ pub fn parse_component_slider<'a, U1, U2>(
 		},
 	)?;
 
-	process_component(file, ctx, node, Component(component), new_id);
+	process_component(ctx, Component(component), new_id, attribs);
 
 	Ok(new_id)
 }

--- a/wgui/src/parser/style.rs
+++ b/wgui/src/parser/style.rs
@@ -78,6 +78,25 @@ pub fn parse_text_style(attribs: &[AttribPair]) -> TextStyle {
 					print_invalid_attrib(key, value);
 				}
 			}
+			"shadow" => {
+				if let Some(color) = parse_color_hex(value) {
+					style.shadow.get_or_insert_default().color = color;
+				}
+			}
+			"shadow_x" => {
+				if let Ok(x) = value.parse::<f32>() {
+					style.shadow.get_or_insert_default().x = x;
+				} else {
+					print_invalid_attrib(key, value);
+				}
+			}
+			"shadow_y" => {
+				if let Ok(y) = value.parse::<f32>() {
+					style.shadow.get_or_insert_default().y = y;
+				} else {
+					print_invalid_attrib(key, value);
+				}
+			}
 			_ => {}
 		}
 	}

--- a/wgui/src/parser/style.rs
+++ b/wgui/src/parser/style.rs
@@ -1,15 +1,13 @@
-use std::rc::Rc;
-
 use taffy::{
-	AlignContent, AlignItems, AlignSelf, BoxSizing, Display, FlexDirection, FlexWrap, JustifyContent,
-	JustifySelf, Overflow,
+	AlignContent, AlignItems, AlignSelf, BoxSizing, Display, FlexDirection, FlexWrap, JustifyContent, JustifySelf,
+	Overflow,
 };
 
 use crate::{
 	drawing,
 	parser::{
-		is_percent, parse_color_hex, parse_f32, parse_percent, parse_size_unit, parse_val,
-		print_invalid_attrib, print_invalid_value,
+		is_percent, parse_color_hex, parse_f32, parse_percent, parse_size_unit, parse_val, print_invalid_attrib,
+		print_invalid_value, AttribPair,
 	},
 	renderer_vk::text::{FontWeight, HorizontalAlign, TextStyle},
 	widget::util::WLength,
@@ -45,11 +43,12 @@ pub fn parse_color_opt(value: &str, color: &mut Option<drawing::Color>) {
 	}
 }
 
-pub fn parse_text_style(attribs: &[(Rc<str>, Rc<str>)]) -> TextStyle {
+pub fn parse_text_style(attribs: &[AttribPair]) -> TextStyle {
 	let mut style = TextStyle::default();
 
-	for (key, value) in attribs {
-		match key.as_ref() {
+	for pair in attribs {
+		let (key, value) = (pair.attrib.as_ref(), pair.value.as_ref());
+		match key {
 			"color" => {
 				if let Some(color) = parse_color_hex(value) {
 					style.color = Some(color);
@@ -88,10 +87,11 @@ pub fn parse_text_style(attribs: &[(Rc<str>, Rc<str>)]) -> TextStyle {
 
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::cognitive_complexity)]
-pub fn parse_style(attribs: &[(Rc<str>, Rc<str>)]) -> taffy::Style {
+pub fn parse_style(attribs: &[AttribPair]) -> taffy::Style {
 	let mut style = taffy::Style::default();
 
-	for (key, value) in attribs {
+	for pair in attribs {
+		let (key, value) = (pair.attrib.as_ref(), pair.value.as_ref());
 		match key.as_ref() {
 			"display" => match value.as_ref() {
 				"flex" => style.display = Display::Flex,

--- a/wgui/src/parser/widget_div.rs
+++ b/wgui/src/parser/widget_div.rs
@@ -1,9 +1,6 @@
 use crate::{
 	layout::WidgetID,
-	parser::{
-		ParserContext, ParserFile, iter_attribs, parse_children, parse_widget_universal,
-		style::parse_style,
-	},
+	parser::{parse_children, parse_widget_universal, style::parse_style, AttribPair, ParserContext, ParserFile},
 	widget::div::WidgetDiv,
 };
 
@@ -12,15 +9,13 @@ pub fn parse_widget_div<'a, U1, U2>(
 	ctx: &mut ParserContext<U1, U2>,
 	node: roxmltree::Node<'a, 'a>,
 	parent_id: WidgetID,
+	attribs: &[AttribPair],
 ) -> anyhow::Result<WidgetID> {
-	let attribs: Vec<_> = iter_attribs(file, ctx, &node, false).collect();
-	let style = parse_style(&attribs);
+	let style = parse_style(attribs);
 
-	let (new_id, _) = ctx
-		.layout
-		.add_child(parent_id, WidgetDiv::create(), style)?;
+	let (new_id, _) = ctx.layout.add_child(parent_id, WidgetDiv::create(), style)?;
 
-	parse_widget_universal(file, ctx, node, new_id);
+	parse_widget_universal(ctx, new_id, attribs);
 	parse_children(file, ctx, node, new_id)?;
 
 	Ok(new_id)

--- a/wgui/src/parser/widget_rectangle.rs
+++ b/wgui/src/parser/widget_rectangle.rs
@@ -2,9 +2,9 @@ use crate::{
 	drawing::GradientMode,
 	layout::WidgetID,
 	parser::{
-		ParserContext, ParserFile, iter_attribs, parse_children, parse_widget_universal,
-		print_invalid_attrib,
+		parse_children, parse_widget_universal, print_invalid_attrib,
 		style::{parse_color, parse_round, parse_style},
+		AttribPair, ParserContext, ParserFile,
 	},
 	widget::rectangle::{WidgetRectangle, WidgetRectangleParams},
 };
@@ -14,42 +14,43 @@ pub fn parse_widget_rectangle<'a, U1, U2>(
 	ctx: &mut ParserContext<U1, U2>,
 	node: roxmltree::Node<'a, 'a>,
 	parent_id: WidgetID,
+	attribs: &[AttribPair],
 ) -> anyhow::Result<WidgetID> {
 	let mut params = WidgetRectangleParams::default();
-	let attribs: Vec<_> = iter_attribs(file, ctx, &node, false).collect();
 	let style = parse_style(&attribs);
 
-	for (key, value) in attribs {
-		match &*key {
+	for pair in attribs {
+		let (key, value) = (pair.attrib.as_ref(), pair.value.as_ref());
+		match key {
 			"color" => {
-				parse_color(&value, &mut params.color);
+				parse_color(value, &mut params.color);
 			}
 			"color2" => {
-				parse_color(&value, &mut params.color2);
+				parse_color(value, &mut params.color2);
 			}
 			"gradient" => {
-				params.gradient = match &*value {
+				params.gradient = match value {
 					"horizontal" => GradientMode::Horizontal,
 					"vertical" => GradientMode::Vertical,
 					"radial" => GradientMode::Radial,
 					"none" => GradientMode::None,
 					_ => {
-						print_invalid_attrib(&key, &value);
+						print_invalid_attrib(key, value);
 						GradientMode::None
 					}
 				}
 			}
 			"round" => {
-				parse_round(&value, &mut params.round);
+				parse_round(value, &mut params.round);
 			}
 			"border" => {
 				params.border = value.parse().unwrap_or_else(|_| {
-					print_invalid_attrib(&key, &value);
+					print_invalid_attrib(key, value);
 					0.0
 				});
 			}
 			"border_color" => {
-				parse_color(&value, &mut params.border_color);
+				parse_color(value, &mut params.border_color);
 			}
 			_ => {}
 		}
@@ -59,7 +60,7 @@ pub fn parse_widget_rectangle<'a, U1, U2>(
 		.layout
 		.add_child(parent_id, WidgetRectangle::create(params), style)?;
 
-	parse_widget_universal(file, ctx, node, new_id);
+	parse_widget_universal(ctx, new_id, attribs);
 	parse_children(file, ctx, node, new_id)?;
 
 	Ok(new_id)

--- a/wgui/src/renderer_vk/text/mod.rs
+++ b/wgui/src/renderer_vk/text/mod.rs
@@ -25,6 +25,23 @@ const DEFAULT_LINE_HEIGHT_RATIO: f32 = 1.43;
 pub(crate) const DEFAULT_METRICS: Metrics =
 	Metrics::new(DEFAULT_FONT_SIZE, DEFAULT_FONT_SIZE * DEFAULT_LINE_HEIGHT_RATIO);
 
+#[derive(Clone)]
+pub struct TextShadow {
+	pub y: f32,
+	pub x: f32,
+	pub color: drawing::Color,
+}
+
+impl Default for TextShadow {
+	fn default() -> Self {
+		Self {
+			y: 1.5,
+			x: 1.5,
+			color: drawing::Color::default(),
+		}
+	}
+}
+
 #[derive(Default, Clone)]
 pub struct TextStyle {
 	pub size: Option<f32>,
@@ -34,6 +51,7 @@ pub struct TextStyle {
 	pub weight: Option<FontWeight>,
 	pub align: Option<HorizontalAlign>,
 	pub wrap: bool,
+	pub shadow: Option<TextShadow>,
 }
 
 impl From<&TextStyle> for Attrs<'_> {
@@ -60,7 +78,11 @@ impl From<&TextStyle> for Metrics {
 
 impl From<&TextStyle> for Wrap {
 	fn from(value: &TextStyle) -> Self {
-		if value.wrap { Self::WordOrGlyph } else { Self::None }
+		if value.wrap {
+			Self::WordOrGlyph
+		} else {
+			Self::None
+		}
 	}
 }
 
@@ -199,6 +221,8 @@ pub struct TextArea<'a> {
 	pub bounds: TextBounds,
 	/// The default color of the text area.
 	pub default_color: Color,
+	/// Override text color. Used for shadow.
+	pub override_color: Option<Color>,
 	/// Additional custom glyphs to render.
 	pub custom_glyphs: &'a [CustomGlyph],
 	/// Text transformation

--- a/wgui/src/renderer_vk/text/text_renderer.rs
+++ b/wgui/src/renderer_vk/text/text_renderer.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 
 use super::{
-	ContentType, FontSystem, GlyphDetails, GpuCacheStatus, SwashCache, TextArea,
 	custom_glyph::{CustomGlyphCacheKey, RasterizeCustomGlyphRequest, RasterizedCustomGlyph},
 	text_atlas::{GlyphVertex, TextAtlas, TextPipeline},
+	ContentType, FontSystem, GlyphDetails, GpuCacheStatus, SwashCache, TextArea,
 };
 use cosmic_text::{Color, SubpixelBin, SwashContent};
 use glam::{Mat4, Vec2, Vec3};
@@ -96,7 +96,10 @@ impl TextRenderer {
 					y_bin,
 				});
 
-				let color = glyph.color.unwrap_or(text_area.default_color);
+				let color = text_area
+					.override_color
+					.or(glyph.color)
+					.unwrap_or(text_area.default_color);
 
 				if let Some(glyph_to_render) = prepare_glyph(
 					&mut PrepareGlyphParams {
@@ -168,10 +171,10 @@ impl TextRenderer {
 				for glyph in run.glyphs {
 					let physical_glyph = glyph.physical((text_area.left, text_area.top), text_area.scale);
 
-					let color = match glyph.color_opt {
-						Some(some) => some,
-						None => text_area.default_color,
-					};
+					let color = text_area
+						.override_color
+						.or(glyph.color_opt)
+						.unwrap_or(text_area.default_color);
 
 					if let Some(glyph_to_render) = prepare_glyph(
 						&mut PrepareGlyphParams {

--- a/wgui/src/widget/label.rs
+++ b/wgui/src/widget/label.rs
@@ -10,7 +10,7 @@ use crate::{
 	globals::Globals,
 	i18n::{I18n, Translation},
 	layout::WidgetID,
-	renderer_vk::text::{FONT_SYSTEM, TextStyle},
+	renderer_vk::text::{TextStyle, FONT_SYSTEM},
 };
 
 use super::{WidgetObj, WidgetState};
@@ -124,6 +124,7 @@ impl WidgetObj for WidgetLabel {
 				transform: state.transform_stack.get().transform,
 			},
 			self.buffer.clone(),
+			self.params.style.shadow.clone(),
 		));
 	}
 

--- a/wgui/src/widget/sprite.rs
+++ b/wgui/src/widget/sprite.rs
@@ -7,8 +7,8 @@ use crate::{
 	drawing::{self, PrimitiveExtent},
 	layout::WidgetID,
 	renderer_vk::text::{
-		DEFAULT_METRICS, FONT_SYSTEM,
 		custom_glyph::{CustomGlyph, CustomGlyphData},
+		DEFAULT_METRICS, FONT_SYSTEM,
 	},
 };
 
@@ -81,6 +81,7 @@ impl WidgetObj for WidgetSprite {
 					transform: state.transform_stack.get().transform,
 				},
 				Rc::new(RefCell::new(buffer)),
+				None,
 			));
 		}
 	}

--- a/wlx-overlay-s/src/assets/gui/watch.xml
+++ b/wlx-overlay-s/src/assets/gui/watch.xml
@@ -20,13 +20,16 @@
 
   <template name="Device">
     <sprite color="~device_color" width="${size}" height="${size}" src="${src}" />
+      <div position="absolute" margin_top="10" margin_left="9">
+        <label _source="battery" _device="${device}" size="18" shadow="#000000" weight="bold" />
+      </div>
   </template>
 
   <template name="Set">
     <Button macro="button_style" _press="::OverlayToggle ${handle}">
       <sprite width="40" height="40" color="~set_color" src="watch/set2.svg" />
-      <div position="absolute" margin_top="11">
-        <label text="${display}" size="24" color="#000000" weight="bold" />
+      <div position="absolute" margin_top="9">
+        <label text="${display}" size="24" color="#00050F" weight="bold" />
       </div>
     </Button>
   </template>
@@ -35,12 +38,12 @@
     <div width="400" height="200">
       <rectangle width="100%" height="100%" padding="4" box_sizing="content_box" flex_wrap="wrap" flex_direction="column" gap="4" color="~bg_color">
         <div width="100%" flex_direction="row">
-          <Device src="watch/hmd.svg" size="40" />
-          <Device src="watch/controller_l.svg" size="36" />
-          <Device src="watch/controller_r.svg" size="36" />
-          <Device src="watch/track3.svg" size="40" />
-          <Device src="watch/track3.svg" size="40" />
-          <Device src="watch/track3.svg" size="40" />
+          <Device src="watch/hmd.svg" size="40" device="0" />
+          <Device src="watch/controller_l.svg" size="36" device="1" />
+          <Device src="watch/controller_r.svg" size="36" device="2" />
+          <Device src="watch/track3.svg" size="40" device="3" />
+          <Device src="watch/track3.svg" size="40" device="4" />
+          <Device src="watch/track3.svg" size="40" device="5" />
         </div>
         <div flex_direction="row">
           <div flex_direction="column" padding="4">

--- a/wlx-overlay-s/src/gui/panel/button.rs
+++ b/wlx-overlay-s/src/gui/panel/button.rs
@@ -11,7 +11,7 @@ use wgui::{
 
 use crate::{
     backend::{common::OverlaySelector, overlay::OverlayID, task::TaskType, wayvr::WayVRAction},
-    config::{AStrSetExt, save_layout},
+    config::{save_layout, AStrSetExt},
     state::AppState,
 };
 
@@ -24,8 +24,8 @@ pub(super) fn setup_custom_button<S>(
     _app: &AppState,
 ) {
     const EVENTS: [(&str, EventListenerKind); 2] = [
-        ("press", EventListenerKind::MousePress),
-        ("release", EventListenerKind::MouseRelease),
+        ("_press", EventListenerKind::MousePress),
+        ("_release", EventListenerKind::MouseRelease),
     ];
 
     for (name, kind) in &EVENTS {

--- a/wlx-overlay-s/src/gui/panel/label.rs
+++ b/wlx-overlay-s/src/gui/panel/label.rs
@@ -376,16 +376,13 @@ fn battery_on_tick(
     app: &AppState,
 ) {
     let device = app.input_state.devices.get(state.device);
-
-    let tags = ["", "H", "L", "R", "T"];
-
     let label = data.obj.get_as_mut::<WidgetLabel>().unwrap();
 
     if let Some(device) = device
         && let Some(soc) = device.soc
     {
         let soc = (soc * 100.).min(99.) as u32;
-        let text = format!("{}{}", tags[device.role as usize], soc);
+        let text = soc.to_string();
         let color = if device.charging {
             state.charging_color
         } else if soc < state.low_threshold {

--- a/wlx-overlay-s/src/gui/panel/label.rs
+++ b/wlx-overlay-s/src/gui/panel/label.rs
@@ -15,7 +15,7 @@ use wgui::{
     event::{self, EventCallback, EventListenerCollection, ListenerHandleVec},
     i18n::Translation,
     layout::Layout,
-    parser::{CustomAttribsInfoOwned, parse_color_hex},
+    parser::{parse_color_hex, CustomAttribsInfoOwned},
     widget::label::WidgetLabel,
 };
 
@@ -31,14 +31,14 @@ pub(super) fn setup_custom_label<S>(
     listener_handles: &mut ListenerHandleVec,
     app: &AppState,
 ) {
-    let Some(source) = attribs.get_value("source") else {
+    let Some(source) = attribs.get_value("_source") else {
         log::warn!("custom label with no source!");
         return;
     };
 
     let callback: EventCallback<AppState, S> = match source {
         "shell" => {
-            let Some(exec) = attribs.get_value("exec") else {
+            let Some(exec) = attribs.get_value("_exec") else {
                 log::warn!("label with shell source but no exec attribute!");
                 return;
             };
@@ -57,7 +57,7 @@ pub(super) fn setup_custom_label<S>(
             })
         }
         "fifo" => {
-            let Some(path) = attribs.get_value("path") else {
+            let Some(path) = attribs.get_value("_path") else {
                 log::warn!("label with fifo source but no path attribute!");
                 return;
             };
@@ -76,7 +76,7 @@ pub(super) fn setup_custom_label<S>(
         }
         "battery" => {
             let Some(device) = attribs
-                .get_value("device")
+                .get_value("_device")
                 .and_then(|s| s.parse::<usize>().ok())
             else {
                 log::warn!("label with battery source but no device attribute!");
@@ -85,19 +85,19 @@ pub(super) fn setup_custom_label<S>(
 
             let state = BatteryLabelState {
                 low_color: attribs
-                    .get_value("low_color")
+                    .get_value("_low_color")
                     .and_then(parse_color_hex)
                     .unwrap_or(BAT_LOW),
                 normal_color: attribs
-                    .get_value("normal_color")
+                    .get_value("_normal_color")
                     .and_then(parse_color_hex)
                     .unwrap_or(BAT_NORMAL),
                 charging_color: attribs
-                    .get_value("charging_color")
+                    .get_value("_charging_color")
                     .and_then(parse_color_hex)
                     .unwrap_or(BAT_CHARGING),
                 low_threshold: attribs
-                    .get_value("low_threshold")
+                    .get_value("_low_threshold")
                     .and_then(|s| s.parse().ok())
                     .unwrap_or(BAT_LOW_THRESHOLD),
                 device,
@@ -108,7 +108,7 @@ pub(super) fn setup_custom_label<S>(
             })
         }
         "clock" => {
-            let Some(display) = attribs.get_value("display") else {
+            let Some(display) = attribs.get_value("_display") else {
                 log::warn!("label with clock source but no display attribute!");
                 return;
             };
@@ -116,7 +116,7 @@ pub(super) fn setup_custom_label<S>(
             let format = match display {
                 "name" => {
                     let maybe_pretty_tz = attribs
-                        .get_value("timezone")
+                        .get_value("_timezone")
                         .and_then(|tz| tz.parse::<usize>().ok())
                         .and_then(|tz_idx| app.session.config.timezones.get(tz_idx))
                         .and_then(|tz_name| {
@@ -152,7 +152,7 @@ pub(super) fn setup_custom_label<S>(
             };
 
             let tz_str = attribs
-                .get_value("timezone")
+                .get_value("_timezone")
                 .and_then(|tz| tz.parse::<usize>().ok())
                 .and_then(|tz_idx| app.session.config.timezones.get(tz_idx));
 

--- a/wlx-overlay-s/src/overlays/keyboard/builder.rs
+++ b/wlx-overlay-s/src/overlays/keyboard/builder.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, rc::Rc};
 
-use glam::{Mat4, Vec2, Vec3, vec2, vec3a};
+use glam::{vec2, vec3a, Mat4, Vec2, Vec3};
 use wgui::{
     animation::{Animation, AnimationEasing},
     drawing::Color,
@@ -20,13 +20,13 @@ use crate::{
     backend::overlay::{OverlayData, OverlayState, Positioning},
     gui::panel::GuiPanel,
     state::AppState,
-    subsystem::hid::{ALT, CTRL, META, SHIFT, SUPER, XkbKeymap},
+    subsystem::hid::{XkbKeymap, ALT, CTRL, META, SHIFT, SUPER},
 };
 
 use super::{
-    KEYBOARD_NAME, KeyButtonData, KeyState, KeyboardBackend, KeyboardState, handle_press,
-    handle_release,
+    handle_press, handle_release,
     layout::{self, AltModifier, KeyCapType},
+    KeyButtonData, KeyState, KeyboardBackend, KeyboardState, KEYBOARD_NAME,
 };
 
 const BACKGROUND_PADDING: f32 = 4.;


### PR DESCRIPTION
Instead of doing `iter_attribs` inside the parser of each element type (and sometimes multiple times per element), pre-process attributes once per element and store the results.

To keep to `Rc<str>` and avoid string copies, the custom attribs keys are back to being reported with the leading `_` included.