### PR TITLE
prevent the mode from changing during a click

### DIFF
--- a/wlx-overlay-s/src/backend/input.rs
+++ b/wlx-overlay-s/src/backend/input.rs
@@ -72,42 +72,45 @@ impl InputState {
                 hand.last_click = Instant::now();
             }
 
-            if hand.now.click_modifier_right {
-                hand.interaction.mode = PointerMode::Right;
-                continue;
-            }
-
-            if hand.now.click_modifier_middle {
-                hand.interaction.mode = PointerMode::Middle;
-                continue;
-            }
-
-            let hmd_up = self.hmd.transform_vector3a(Vec3A::Y);
-            let dot = hmd_up.dot(hand.pose.transform_vector3a(Vec3A::X))
-                * 2.0f32.mul_add(-(hand.idx as f32), 1.0);
-
-            hand.interaction.mode = if dot < -0.85 {
-                PointerMode::Right
-            } else if dot > 0.7 {
-                PointerMode::Middle
-            } else {
-                PointerMode::Left
-            };
-
-            let middle_click_orientation = false;
-            let right_click_orientation = false;
-            match hand.interaction.mode {
-                PointerMode::Middle => {
-                    if !middle_click_orientation {
-                        hand.interaction.mode = PointerMode::Left;
-                    }
+            // Prevent the mode from changing during a click
+            if !hand.before.click {
+                if hand.now.click_modifier_right {
+                    hand.interaction.mode = PointerMode::Right;
+                    continue;
                 }
-                PointerMode::Right => {
-                    if !right_click_orientation {
-                        hand.interaction.mode = PointerMode::Left;
-                    }
+
+                if hand.now.click_modifier_middle {
+                    hand.interaction.mode = PointerMode::Middle;
+                    continue;
                 }
-                _ => {}
+
+                let hmd_up = self.hmd.transform_vector3a(Vec3A::Y);
+                let dot = hmd_up.dot(hand.pose.transform_vector3a(Vec3A::X))
+                    * 2.0f32.mul_add(-(hand.idx as f32), 1.0);
+
+                hand.interaction.mode = if dot < -0.85 {
+                    PointerMode::Right
+                } else if dot > 0.7 {
+                    PointerMode::Middle
+                } else {
+                    PointerMode::Left
+                };
+
+                let middle_click_orientation = false;
+                let right_click_orientation = false;
+                match hand.interaction.mode {
+                    PointerMode::Middle => {
+                        if !middle_click_orientation {
+                            hand.interaction.mode = PointerMode::Left;
+                        }
+                    }
+                    PointerMode::Right => {
+                        if !right_click_orientation {
+                            hand.interaction.mode = PointerMode::Left;
+                        }
+                    }
+                    _ => {}
+                }
             }
 
             if hand.now.alt_click != hand.before.alt_click {


### PR DESCRIPTION
Fixes mouse buttons getting stuck if trigger is released in a different mode than the initial click.

This has driven me insane a couple times, what can happen is if you touch the button to turn the laser purple or orange, and let go of it before releasing the trigger, the mouse button will remain clicked, which ends up looking like the desktop being unresponsive (stuck icons, can't drag and drop, and so on).