### PR TITLE
next: Update OVR Toolkit OSC Parity

### DIFF
--- a/wlx-overlay-s/src/subsystem/osc.rs
+++ b/wlx-overlay-s/src/subsystem/osc.rs
@@ -131,15 +131,7 @@ impl OscSender {
                 let parameter = match device.role {
                     TrackedDeviceRole::None => continue,
                     TrackedDeviceRole::Hmd => {
-                        // legacy OVR Toolkit style (int)
-                        // as of 20 Nov 2024 OVR Toolkit uses int 0-100, but this may change in a future update.
-                        //TODO: update this once their implementation matches their docs
-                        self.send_message(
-                            "/avatar/parameters/hmdBattery".into(),
-                            vec![OscType::Int((level * 100.0f32).round() as i32)],
-                        )?;
-
-                        "headset"
+                        "hmd"
                     }
                     TrackedDeviceRole::LeftHand => {
                         controller_count += 1;


### PR DESCRIPTION
Updates the `hmdBattery` parameter to match OVR Toolkit, and removes the old `headsetBattery` float parameter I added as a stepping stone.

The wiki tab should remove the old `/avatar/parameters/hmdBattery` point and replace the remaining `headsetBattery` and `headsetCharging` with `hmdBattery` and `hmdCharging`
