### PR TITLE
feat: add X-XR-Plugin flag and X-XR-Plugin-Exec to .desktop file

### DIFF
--- a/wlx-overlay-s/wlx-overlay-s.desktop
+++ b/wlx-overlay-s/wlx-overlay-s.desktop
@@ -5,3 +5,5 @@ Exec=wlx-overlay-s
 Icon=wlx-overlay-s
 Terminal=true
 Categories=Utility;X-WiVRn-VR;
+X-XR-Plugin=true
+X-XR-Plugin-Exec=wlx-overlay-s --openxr


### PR DESCRIPTION
This change is part of a new initiative in Envision to revamp the plugin system. The new system is such that Envision will no longer install plugins on its own, instead it will detect system provided plugin applications via the X-XR-Plugin flag, and be instructed on a specific command to use with the optional X-XR-Plugin-Exec.

This proposed specification is detailed in the following issue: <https://gitlab.com/gabmus/envision/-/issues/250>