### PR TITLE
feat: add wayvrctl ipc for overlay show hide

### DIFF
--- a/wayvr-ipc/src/client.rs
+++ b/wayvr-ipc/src/client.rs
@@ -495,6 +495,13 @@ impl WayVRClient {
 		Ok(())
 	}
 
+	pub async fn fn_wlx_overlay_show_hide(
+		client: WayVRClientMutex,
+	) -> anyhow::Result<()> {
+		send_only!(client, &PacketClient::WlxShowHide);
+		Ok(())
+	}
+
 	pub async fn fn_wlx_modify_panel(
 		client: WayVRClientMutex,
 		params: packet_client::WlxModifyPanelParams,

--- a/wayvr-ipc/src/packet_client.rs
+++ b/wayvr-ipc/src/packet_client.rs
@@ -86,4 +86,5 @@ pub enum PacketClient {
 	WlxInputState(Serial),
 	WlxModifyPanel(WlxModifyPanelParams),
 	WlxDeviceHaptics(usize, WlxHapticsParams),
+	WlxShowHide,
 }

--- a/wayvrctl/src/helper.rs
+++ b/wayvrctl/src/helper.rs
@@ -236,6 +236,18 @@ pub async fn wlx_device_haptics(
     )
 }
 
+pub async fn wlx_overlay_show_hide(
+    state: &mut WayVRClientState,
+) {
+    handle_empty_result(
+        WayVRClient::fn_wlx_overlay_show_hide(
+            state.wayvr_client.clone(),
+        )
+        .await
+        .context("failed to trigger overlay show hide"),
+    )
+}
+
 pub async fn wlx_panel_modify(
     state: &mut WayVRClientState,
     overlay: String,

--- a/wayvrctl/src/main.rs
+++ b/wayvrctl/src/main.rs
@@ -10,7 +10,7 @@ use env_logger::Env;
 use wayvr_ipc::{client::WayVRClient, ipc, packet_client};
 
 use crate::helper::{
-    WayVRClientState, wlx_device_haptics, wlx_input_state, wlx_panel_modify, wvr_display_create,
+    WayVRClientState, wlx_overlay_show_hide, wlx_device_haptics, wlx_input_state, wlx_panel_modify, wvr_display_create,
     wvr_display_get, wvr_display_list, wvr_display_remove, wvr_display_set_visible,
     wvr_display_window_list, wvr_process_get, wvr_process_launch, wvr_process_list,
     wvr_process_terminate, wvr_window_set_visible,
@@ -169,6 +169,10 @@ async fn run_once(state: &mut WayVRClientState, args: Args) -> anyhow::Result<()
         } => {
             wlx_device_haptics(state, device, intensity, duration, frequency).await;
         }
+        Subcommands::ShowHide {
+        } => {
+            wlx_overlay_show_hide(state).await;
+        }
         Subcommands::PanelModify {
             overlay,
             element,
@@ -293,6 +297,8 @@ enum Subcommands {
         #[arg(short, long, default_value = "0.1")]
         frequency: f32,
     },
+    /// Toggle overlay show or hide
+    ShowHide,
     /// Apply a modification to a panel element
     PanelModify {
         /// The name of the overlay (XML file name without extension)

--- a/wlx-overlay-s/src/ipc/events.rs
+++ b/wlx-overlay-s/src/ipc/events.rs
@@ -165,6 +165,10 @@ where
                 app.tasks
                     .enqueue(TaskType::Input(InputTask::Haptics { device, haptics }));
             }
+            WayVRSignal::ShowHide => {
+                app.tasks
+                    .enqueue(TaskType::Overlay(OverlayTask::ShowHide));
+            }
             WayVRSignal::DropOverlay(overlay_id) => {
                 app.tasks
                     .enqueue(TaskType::Overlay(OverlayTask::Drop(OverlaySelector::Id(

--- a/wlx-overlay-s/src/ipc/ipc_server.rs
+++ b/wlx-overlay-s/src/ipc/ipc_server.rs
@@ -522,6 +522,12 @@ impl Connection {
         ));
     }
 
+    fn handle_wlx_overlay_show_hide(
+        params: &mut TickParams
+    ) {
+        params.signals.send(WayVRSignal::ShowHide);
+    }
+
     fn handle_wlx_panel(
         params: &mut TickParams,
         custom_params: packet_client::WlxModifyPanelParams,
@@ -623,6 +629,9 @@ impl Connection {
             }
             PacketClient::WlxDeviceHaptics(device, haptics_params) => {
                 Self::handle_wlx_device_haptics(params, device, haptics_params);
+            }
+            PacketClient::WlxShowHide => {
+                Self::handle_wlx_overlay_show_hide(params);
             }
             PacketClient::WlxModifyPanel(custom_params) => {
                 Self::handle_wlx_panel(params, custom_params);

--- a/wlx-overlay-s/src/ipc/signal.rs
+++ b/wlx-overlay-s/src/ipc/signal.rs
@@ -16,5 +16,6 @@ pub enum WayVRSignal {
     Haptics(crate::backend::input::Haptics),
     DeviceHaptics(usize, crate::backend::input::Haptics),
     DropOverlay(crate::windowing::OverlayID),
+    ShowHide,
     CustomTask(crate::backend::task::ModifyPanelTask),
 }


### PR DESCRIPTION
## Summary

A POC for controlling showing and hiding of overlay.

To toggle:
```sh
./target/release/wayvrctl show-hide
```

<img width="621" height="451" alt="image" src="https://github.com/user-attachments/assets/246fecd8-574a-439b-ac84-157a7381ca68" />


## Related
Conversation: https://matrix.to/#/!cBgVuSQxzXsatAyyAT:matrix.org/$urcsIVtbFZBLPj6IhM1I0u0xqtJGHQwgFywlsGpxMqM?via=matrix.org&via=ckie.dev&via=t2bot.io
