### PR TITLE
Prevent crash when changing back from stereo to none

### DIFF
--- a/wlx-overlay-s/src/overlays/screen/capture.rs
+++ b/wlx-overlay-s/src/overlays/screen/capture.rs
@@ -208,6 +208,12 @@ impl ScreenPipeline {
         self.buf_alpha.write()?[0] = rdr.alpha;
 
         for (eye, cmd_buf) in rdr.cmd_bufs.iter_mut().enumerate() {
+            // Only render if we have a pass for this eye
+            if eye >= self.pass.len() {
+                log::warn!("Eye {eye} not available during render");
+                continue;
+            }
+
             let current = &mut self.pass[eye];
 
             current


### PR DESCRIPTION
## Summary

Handle crash when switching from stereo to none

## Related issue

Log

```rs
  2026-01-06T13:25:59.241279Z ERROR panic: thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 1': wlx-overlay-s/src/overlays/screen/capture.rs:211
   0: log_panics::Config::install_panic_hook::{{closure}}
   1: std::panicking::panic_with_hook
   2: std::panicking::panic_handler::{{closure}}
   3: std::sys::backtrace::__rust_end_short_backtrace
   4: __rustc::rust_begin_unwind
   5: core::panicking::panic_fmt
   6: core::panicking::panic_bounds_check
   7: wlx_overlay_s::overlays::screen::capture::ScreenPipeline::render
   8: <wlx_overlay_s::overlays::screen::backend::ScreenBackend as wlx_overlay_s::windowing::backend::OverlayBackend>::render
   9: <wlx_overlay_s::overlays::edit::EditModeBackendWrapper as wlx_overlay_s::windowing::backend::OverlayBackend>::render
  10: wlx_overlay_s::backend::openxr::openxr_run
  11: wlx_overlay_s::main
  12: std::sys::backtrace::__rust_begin_short_backtrace
  13: std::rt::lang_start::{{closure}}
  14: std::rt::lang_start_internal
  15: main
  16: <unknown>
  17: __libc_start_main
  18: _start
```

Similar reports:
- https://matrix.to/#/!cBgVuSQxzXsatAyyAT:matrix.org/$UBtW72B_kBY48PHS8-nU4z0RDlSw6nuHuj88ul4DcoA?via=matrix.org&via=ckie.dev&via=t2bot.io

### How to reproduce?:
Not sure, this is randomly reproducible for me.
I have 2 connected displays. When `zz-saved-state.json5` is removed, wlx-overlay-s will create 2 sets for me with 1 display per set.


This is how I manage to consistently reproduce this:
1. Ensure wlx-overlay-s is closed
2. Remove `~/.config/wlxoverlay/conf.d/zz-saved-state.json5`
3. Start wlx-overlay-s
4. Enter edit mode, hover on a display
5. Repeat this until crash happen (in this setup, it usually crash during my second attempt)
    1. Change "Stereo" to "Left Right"
    2. Change "Stereo" to "None"



## How is this tested?
When the same condition enter, this PR will show a warning instead of crashing the app.

The screenshot below shows the log when I attempt the reproduce following the steps above.

![crash-on-stereo-render-pass](https://github.com/user-attachments/assets/827d71ef-d7bf-4807-84df-cccc126b369a)