### PR TITLE
support custom formats on clock label in _display

### DIFF
--- a/wlx-overlay-s/src/gui/README.md
+++ b/wlx-overlay-s/src/gui/README.md
@@ -10,7 +10,7 @@ For more, refer to: `wayvrctl panel-modify --help`
 
 Clock labels are driven by the current time, adhering to the user's 12/24 hour setting as well as timezone settings.
 
-Available display values are: `name` (timezone name), `time`, `date`, `dow`
+Available display values are: `name` (timezone name), `time`, `date`, `dow` or a custom [format string](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) like `%H:%M:%S`.
 
 See the Custom Timezones section for more info on timezones. Skip `_timezone` to use local time.
 

--- a/wlx-overlay-s/src/gui/panel/label.rs
+++ b/wlx-overlay-s/src/gui/panel/label.rs
@@ -98,8 +98,7 @@ pub(super) fn setup_custom_label<S: 'static>(
                     }
                 }
                 unk => {
-                    log::warn!("Unknown display value for clock label source: {unk}");
-                    return;
+                    unk
                 }
             };
 


### PR DESCRIPTION
~~i'm not good with rust, if you want me to do the &str and String memory situation differently, pls suggest how.~~

simple and effective. Thanks for the suggestion, I am using this to get seconds on the clock