### PR TITLE
add input blocking on OpenVR

### DIFF
--- a/wayvr/src/backend/openvr/mod.rs
+++ b/wayvr/src/backend/openvr/mod.rs
@@ -240,7 +240,13 @@ pub fn openvr_run(show_by_default: bool, headless: bool) -> Result<(), BackendEr
         let universe = playspace.get_universe();
 
         app.input_state.pre_update();
-        input_source.update(universe.clone(), &mut input_mgr, &mut system_mgr, &mut app);
+        input_source.update(
+            universe.clone(),
+            &mut input_mgr,
+            &mut system_mgr,
+            &mut app,
+            watch_id,
+        );
         app.input_state.post_update(&app.session);
 
         if app


### PR DESCRIPTION
for those who still suffer

needs `Enable global input from overlays (Experimental)` to be turned on in SteamVR developer settings, it's far from perfect, SteamVR keeps the previous input state when blocking, which means you continue to move in the same direction if your thumbstick wasn't centered, but there's nothing we can do about that :/