### PR TITLE
wgui: perf: Scissor render culling

### DIFF
--- a/uidev/assets/gui/various_widgets.xml
+++ b/uidev/assets/gui/various_widgets.xml
@@ -36,7 +36,7 @@
         <div gap="4">
           <Button id="button_red" text="Red button" width="150" height="32" color="#FF0000" tooltip_str="I'm at the top" tooltip_side="top" />
           <Button id="button_aqua" text="Aqua button" width="150" height="32" color="#00FFFF" tooltip_str="I'm at the bottom" tooltip_side="bottom" />
-          <Button id="button_yellow" text="Yellow button" width="150" height="32" color="#FFFF00" tooltip="TESTBED.HELLO_WORLD" tooltip_side="right" />
+          <Button id="button_yellow" text="Yellow button" width="150" height="32" color="#FFFF00" tooltip="TESTBED.HELLO_WORLD" tooltip_side="left" />
         </div>
         <div gap="4">
           <Button id="button_click_me" text="Click me" width="128" height="24" color="#FFFFFF" />

--- a/uidev/src/main.rs
+++ b/uidev/src/main.rs
@@ -359,7 +359,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 						.unwrap();
 
 					if debug_draw_enabled {
-						log::debug!("pass count: {}", draw_result.pass_count);
+						log::debug!(
+							"pass count: {}, primitive commands count: {}",
+							draw_result.pass_count,
+							draw_result.primitive_commands_count
+						);
 					}
 
 					cmd_buf.end_rendering().unwrap();

--- a/wgui/src/components/tooltip.rs
+++ b/wgui/src/components/tooltip.rs
@@ -129,27 +129,34 @@ pub fn construct(ess: &mut ConstructEssentials, params: Params) -> anyhow::Resul
 
 	let transform = Mat4::from_translation(Vec3::new(-0.5, 0.0, 0.0));
 
+	// this value needs to be bigger than rectangle padding sizes due to the
+	// transform stack & scissoring design. Needs investigation, zero-size objects
+	// would result in PushScissorStackResult::OutOfBounds otherwise preventing us
+	// to render the label. Didn't find the best solution for this edge-case yet,
+	// so here it is.
+	let pin_size = 32.0;
+
 	let (pin_left, pin_top, pin_align_items, pin_justify_content) = match params.info.side {
 		TooltipSide::Left => (
-			absolute_boundary.left() - spacing,
-			absolute_boundary.top() + absolute_boundary.size.y / 2.0,
+			absolute_boundary.left() - spacing - pin_size,
+			absolute_boundary.top() + absolute_boundary.size.y / 2.0 - pin_size / 2.0,
 			taffy::AlignItems::Center,
 			taffy::JustifyContent::End,
 		),
 		TooltipSide::Right => (
 			absolute_boundary.left() + absolute_boundary.size.x + spacing,
-			absolute_boundary.top() + absolute_boundary.size.y / 2.0,
+			absolute_boundary.top() + absolute_boundary.size.y / 2.0 - pin_size / 2.0,
 			taffy::AlignItems::Center,
 			taffy::JustifyContent::Start,
 		),
 		TooltipSide::Top => (
-			absolute_boundary.left() + absolute_boundary.size.x / 2.0,
-			absolute_boundary.top() - spacing,
+			absolute_boundary.left() + absolute_boundary.size.x / 2.0 - pin_size / 2.0,
+			absolute_boundary.top() - spacing - pin_size,
 			taffy::AlignItems::End,
 			taffy::JustifyContent::Center,
 		),
 		TooltipSide::Bottom => (
-			absolute_boundary.left() + absolute_boundary.size.x / 2.0,
+			absolute_boundary.left() + absolute_boundary.size.x / 2.0 - pin_size / 2.0,
 			absolute_boundary.top() + absolute_boundary.size.y + spacing,
 			taffy::AlignItems::Baseline,
 			taffy::JustifyContent::Center,
@@ -173,8 +180,8 @@ pub fn construct(ess: &mut ConstructEssentials, params: Params) -> anyhow::Resul
 			},
 			/* important, to make it centered! */
 			size: taffy::Size {
-				width: length(0.0),
-				height: length(0.0),
+				width: length(pin_size),
+				height: length(pin_size),
 			},
 			..Default::default()
 		},

--- a/wgui/src/layout.rs
+++ b/wgui/src/layout.rs
@@ -442,7 +442,7 @@ impl Layout {
 
 		widget.data.cached_absolute_boundary = drawing::Boundary::construct_absolute(&alterables.transform_stack);
 
-		let scissor_pushed = push_scissor_stack(
+		let scissor_result = push_scissor_stack(
 			&mut alterables.transform_stack,
 			&mut alterables.scissor_stack,
 			scroll_shift,
@@ -450,24 +450,24 @@ impl Layout {
 			style,
 		);
 
-		// check children first
-		self.push_event_children(node_id, event, event_result, alterables, user_data)?;
+		if scissor_result.should_display() {
+			// check children first
+			self.push_event_children(node_id, event, event_result, alterables, user_data)?;
 
-		if event_result.can_propagate() {
-			let mut params = EventParams {
-				state: &self.state,
-				layout: l,
-				alterables,
-				node_id,
-				style,
-			};
+			if event_result.can_propagate() {
+				let mut params = EventParams {
+					state: &self.state,
+					layout: l,
+					alterables,
+					node_id,
+					style,
+				};
 
-			widget.process_event(widget_id, node_id, event, event_result, user_data, &mut params)?;
+				widget.process_event(widget_id, node_id, event, event_result, user_data, &mut params)?;
+			}
 		}
 
-		if scissor_pushed {
-			alterables.scissor_stack.pop();
-		}
+		alterables.scissor_stack.pop();
 		alterables.transform_stack.pop();
 
 		Ok(())

--- a/wgui/src/stack.rs
+++ b/wgui/src/stack.rs
@@ -6,6 +6,7 @@ pub trait Pushable<T> {
 	fn push(&mut self, item: &T);
 }
 
+#[derive(Debug)]
 pub struct GenericStack<T, const STACK_MAX: usize> {
 	pub stack: [T; STACK_MAX],
 	top: u8,
@@ -50,7 +51,7 @@ impl<T: StackItem<T>, const STACK_MAX: usize> Default for GenericStack<T, STACK_
 // Transform stack
 // ########################################
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Transform {
 	pub rel_pos: Vec2,
 	pub visual_dim: Vec2, // for convenience
@@ -95,7 +96,7 @@ pub type TransformStack = GenericStack<Transform, 64>;
 // Scissor stack
 // ########################################
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ScissorBoundary(pub drawing::Boundary);
 
 impl Default for ScissorBoundary {
@@ -144,3 +145,10 @@ impl Pushable<ScissorBoundary> for ScissorBoundary {
 }
 
 pub type ScissorStack = GenericStack<ScissorBoundary, 64>;
+
+impl ScissorStack {
+	pub const fn is_out_of_bounds(&self) -> bool {
+		let boundary = &self.get().0;
+		boundary.width() < 0.0 || boundary.height() < 0.0
+	}
+}


### PR DESCRIPTION
Greatly increase rendering performance and minimize draw pass count for large lists.

The improvement is evident in the Games/Applications tab of dash‑frontend,
only widgets that are actually visible are now rendered.