### PR TITLE
Revert aspect ratio calculation change that broke Quest 3 via WiVRn

### DIFF
--- a/wayvr/src/backend/openxr/overlay.rs
+++ b/wayvr/src/backend/openxr/overlay.rs
@@ -97,13 +97,13 @@ impl OverlayWindowData<OpenXrOverlayData> {
 
         let transform = state.transform * self.config.backend.frame_meta().unwrap().transform; // contract
 
-        let aspect_ratio = swapchain.extent[0] as f32 / swapchain.extent[1] as f32;
+        let aspect_ratio = swapchain.extent[1] as f32 / swapchain.extent[0] as f32;
         let (scale_x, scale_y) = if aspect_ratio < 1.0 {
             let major = transform.matrix3.col(0).length();
-            (major * aspect_ratio, major)
+            (major, major * aspect_ratio)
         } else {
             let major = transform.matrix3.col(1).length();
-            (major, major / aspect_ratio)
+            (major / aspect_ratio, major)
         };
 
         let flags = if state.additive {


### PR DESCRIPTION
## Summary

- Reverts commit 5dae6f8 ("fix openxr aspect ratio calculation (#430)") which broke the aspect ratio on Meta Quest 3 when streaming via WiVRn
- The change swapped `width/height` to `height/width` and flipped the scale axes, which caused a stretched/distorted view on Quest 3
- v26.2.0 (before #430) renders correctly; v26.2.1 with #430 produces a visibly wrong aspect ratio

## Context

Using WiVRn v26.2 as the OpenXR runtime to stream to a Quest 3. After updating from v26.2.0 to latest main, the entire VR view became stretched. Bisected to commit 5dae6f8. Reverting it restores the correct aspect ratio.

## Test plan

- [x] Tested on Meta Quest 3 via WiVRn v26.2 — aspect ratio correct after revert
- [ ] Should be verified on other headsets to ensure no regression