### PR TITLE
Revert "fix bindings for wmr controllers"

### DIFF
--- a/wayvr/src/backend/openxr/openxr_actions.json5
+++ b/wayvr/src/backend/openxr/openxr_actions.json5
@@ -261,11 +261,11 @@
       right: "/user/hand/right/input/thumbstick/x"
     },
     show_hide: {
-      left: "/user/hand/left/input/menu/click",
+      left: "/user/hand/left/input/system/click",
     },
     space_drag: {
       double_click: true,
-      right: "/user/hand/left/input/menu/click",
+      right: "/user/hand/left/input/system/click",
     },
     click_modifier_right: {
       left: "/user/hand/left/input/trackpad/dpad_up",
@@ -305,11 +305,11 @@
       right: "/user/hand/right/input/thumbstick/x"
     },
     show_hide: {
-      left: "/user/hand/left/input/menu/click",
+      left: "/user/hand/left/input/system/click",
     },
     space_drag: {
       double_click: true,
-      right: "/user/hand/left/input/menu/click",
+      right: "/user/hand/left/input/system/click",
     },
   },
 


### PR DESCRIPTION
Can we revert 285f6db134852faad2940f630aac89c9818b157f? 

That commit sets the menu button to show and hide and as space drag. This conflicts with the app menu button in almost all apps with these controllers. 

On Windows with the original WMR drivers, SteamVR used joystick click in for it's system overlay, so that's free in most OpenVR games that designed for WMR but joystick click usually conflicts in newer OpenXR games and games that didn't test with WMR on SteamVR. The system button on these controllers would normally open the WMR HoloShell start menu, and since WayVR is usually used as a replacement for that so it makes sense to bind it to that.

The only issue with binding to the system button on these controllers for space drag is that if you hold the button down for too long it turns off the controller... When I was still using these controllers daily with OVR Advanced settings, I had space drag set to double click on the menu buttons, but that did also conflict regularly.