### PR TITLE
wlx-capture: avoid busy loop waiting for screencopy events

### DIFF
--- a/wlx-capture/src/wlr_screencopy.rs
+++ b/wlx-capture/src/wlr_screencopy.rs
@@ -227,9 +227,7 @@ where
     let mut maybe_dmabuf = None;
 
     'receiver: loop {
-        let mut received_event = false;
-        for event in rx.try_iter() {
-            received_event = true;
+        for event in rx.iter() {
             match event {
                 ScreenCopyEvent::Buffer { .. } => {
                     log::trace!("{name}: ScreenCopy Buffer event received");
@@ -368,10 +366,6 @@ where
                     break 'receiver;
                 }
             };
-        }
-
-        if !received_event {
-            client.dispatch();
         }
     }
 

--- a/wlx-capture/src/wlr_screencopy.rs
+++ b/wlx-capture/src/wlr_screencopy.rs
@@ -227,7 +227,9 @@ where
     let mut maybe_dmabuf = None;
 
     'receiver: loop {
+        let mut received_event = false;
         for event in rx.try_iter() {
+            received_event = true;
             match event {
                 ScreenCopyEvent::Buffer { .. } => {
                     log::trace!("{name}: ScreenCopy Buffer event received");
@@ -366,6 +368,10 @@ where
                     break 'receiver;
                 }
             };
+        }
+
+        if !received_event {
+            client.dispatch();
         }
     }
 


### PR DESCRIPTION
screencapture from sway/wlroots sometimes freezes, even though the rest of wayvr still works, including mouse/keyboard input. restarting fixes it.

I finally caught a freeze in action and straced it looping here

```
  Thread 3 / TID 491180:
  wlx_capture::wlr_screencopy::request_screencopy_frame
    at wlx-capture/src/wlr_screencopy.rs:362
  request_id=3132 output_id=62

  Thread 2 / TID 491181:
  wlx_capture::wlr_screencopy::request_screencopy_frame
    at wlx-capture/src/wlr_screencopy.rs:362
  request_id=3739 output_id=63
```

both at

```
  std::sync::mpsc::Receiver<ScreenCopyEvent>::try_recv
  std::sync::mpsc::{impl Iterator for TryIter}::next
  wlx_capture::wlr_screencopy::request_screencopy_frame 
```

So at wlx-capture/src/wlr_screencopy.rs:359 The worker drains rx.try_iter() but if no screencopy events are queued, it immediately loops again without blocking or dispatching more Wayland events.

I'm not really sure if this is the only cause of the freeze bug but it's one of them.