### PR TITLE
Fix mouse mapping on rotated Wayland screens

### DIFF
--- a/wayvr/src/overlays/screen/wl.rs
+++ b/wayvr/src/overlays/screen/wl.rs
@@ -119,7 +119,10 @@ pub fn create_screens_wayland(wl: &mut WlxClient, app: &mut AppState) -> ScreenC
         {
             backend.logical_pos = vec2(output.logical_pos.0 as f32, output.logical_pos.1 as f32);
             backend.logical_size = vec2(output.logical_size.0 as f32, output.logical_size.1 as f32);
-            backend.mouse_transform_original = output.transform;
+            // The captured frame's orientation is corrected at render time (texture UV remap),
+            // so pointer hits land in the upright/logical space of the output. The compositor's
+            // logical coordinates are upright too, hence the mouse maps without rotation.
+            backend.mouse_transform_original = Transform::Normal;
             backend.apply_mouse_transform_with_override(Transform::Undefined);
 
             let window_config = create_screen_from_backend(


### PR DESCRIPTION
When interacting with a rotated Wayland output, the mouse ends up in the wrong
spot - as if the screen wasn't rotated. The screen itself renders upright fine,
only the pointer is off.

Since #530, screen orientation is corrected at render time via texture-UV
remapping, so `hit.uv` is already in the output's upright/logical orientation.
But the screencopy path still set `mouse_transform_original = output.transform`,
which rotated that already-upright UV a second time - landing the cursor on the
un-rotated physical layout.

Fix: map the mouse with `Transform::Normal`. Logical coords for a rotated output
are already upright, so `uv -> logical_pos + uv * logical_size` is correct. X11 already used `Normal`.