### PR TITLE
Add config.yaml defaults, examples, and enum values for handsfree_pointer

### DIFF
--- a/wayvr/src/res/config.yaml
+++ b/wayvr/src/res/config.yaml
@@ -98,6 +98,17 @@
 ## Other values that were previously here are no longer supported.
 #capture_method: auto
 
+## Hands-Free pointer method. This is a permanent setting for the
+## Hands-Free mode options available in the Hands-Free submenu under the
+## virtual keyboard's settings hamburger menu. Note that VR controllers
+## will always work. Options:
+## `none`: No Hands-Free; only VR controllers
+## `hmd`: Head-Mounted Display, Pinch mode, and VR controllers
+## `hmd_only`: Only the Head-Mounted Display and VR controllers
+## `eye_tracking`: Eye Tracking (if supported), Pinch Mode, and VR controllers
+## `eye_tracking_only`: Eye Tracking (if supported) and VR controllers
+#handsfree_pointer: hmd
+
 ## Monado/WiVRn only. Do not send controller input to other VR apps
 ## while WayVR is being hovered. Either hand will block both hand inputs!
 #block_game_input: false

--- a/wlx-common/src/config.rs
+++ b/wlx-common/src/config.rs
@@ -76,15 +76,20 @@ pub enum AltModifier {
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, AsRefStr, EnumString, EnumProperty, VariantArray)]
 pub enum HandsfreePointer {
+	#[serde(alias = "none")]
 	#[strum(props(Translation = "APP_SETTINGS.OPTION.NONE"))]
 	None,
+	#[serde(alias = "hmd")]
 	#[strum(props(Translation = "APP_SETTINGS.OPTION.HMD_PINCH"))]
 	#[default]
 	Hmd,
+	#[serde(alias = "hmd_only")]
 	#[strum(props(Translation = "APP_SETTINGS.OPTION.HMD_ONLY"))]
 	HmdOnly,
+	#[serde(alias = "eye_tracking")]
 	#[strum(props(Translation = "APP_SETTINGS.OPTION.EYE_PINCH"))]
 	EyeTracking,
+	#[serde(alias = "eye_tracking_only")]
 	#[strum(props(Translation = "APP_SETTINGS.OPTION.EYE_ONLY"))]
 	EyeTrackingOnly,
 }


### PR DESCRIPTION
The configuration system already processed that setting with a default of 'hmd': Head-Mounted Display, Pinch Mode, and VR controllers. This makes that overt while allow it to be changed without needing to use the watch menu in each session.

* Created serde defaults for the hands-free pointer values
* Added an explanation of the field and values to the default config.yaml
