### PR TITLE
make space_reset obey space_drag_affects_world

### DIFF
--- a/wayvr/src/backend/openvr/playspace.rs
+++ b/wayvr/src/backend/openvr/playspace.rs
@@ -49,7 +49,7 @@ impl PlayspaceMover {
                 self.fix_floor(chaperone_mgr, app, overlays);
             }
             PlayspaceTask::Reset => {
-                self.reset_offset(chaperone_mgr, overlays, &mut app.anchor);
+                self.reset_offset(chaperone_mgr, app, overlays);
             }
             PlayspaceTask::Recenter => {
                 self.recenter(chaperone_mgr, app, overlays);
@@ -181,7 +181,7 @@ impl PlayspaceMover {
 
         for pointer in &app.input_state.pointers {
             if pointer.now.space_reset && !pointer.before.space_reset {
-                self.reset_offset(chaperone_mgr, overlays, &mut app.anchor);
+                self.reset_offset(chaperone_mgr, app, overlays);
                 log::info!("Space reset");
                 return;
             }
@@ -191,8 +191,8 @@ impl PlayspaceMover {
     pub fn reset_offset(
         &mut self,
         chaperone_mgr: &mut ChaperoneSetupManager,
+        app: &mut AppState,
         overlays: &mut OverlayWindowManager<OpenVrOverlayData>,
-        anchor: &mut Affine3A,
     ) {
         let Some(before) = get_working_copy(&self.universe, chaperone_mgr) else {
             log::warn!("Can't reset offset - failed to get zero pose");
@@ -207,7 +207,9 @@ impl PlayspaceMover {
         set_working_copy(&self.universe, chaperone_mgr, &xform);
         chaperone_mgr.commit_working_copy(EChaperoneConfigFile::EChaperoneConfigFile_Live);
 
-        playspace_common::shift_world(overlays, anchor, &before, &xform);
+        if !app.session.config.space_drag_affects_world {
+            playspace_common::shift_world(overlays, &mut app.anchor, &before, &xform);
+        }
 
         if self.drag.is_some() {
             log::info!("Space drag interrupted by manual reset");

--- a/wayvr/src/backend/openvr/playspace.rs
+++ b/wayvr/src/backend/openvr/playspace.rs
@@ -95,7 +95,11 @@ impl PlayspaceMover {
                 * -1.0;
             space_transform.translation = offset;
 
+            let before_pose = data.pose;
             data.pose *= space_transform;
+            if !app.session.config.space_drag_affects_world {
+                playspace_common::shift_world(overlays, &mut app.anchor, &before_pose, &data.pose);
+            }
             data.hand_pose = new_hand;
 
             if self.universe == ETrackingUniverseOrigin::TrackingUniverseStanding {
@@ -243,7 +247,9 @@ impl PlayspaceMover {
         set_working_copy(&self.universe, chaperone_mgr, &mat);
         chaperone_mgr.commit_working_copy(EChaperoneConfigFile::EChaperoneConfigFile_Live);
 
-        playspace_common::shift_world(overlays, anchor, &before, &mat);
+        if !app.session.config.space_drag_affects_world {
+            playspace_common::shift_world(overlays, anchor, &before, &mat);
+        }
 
         if self.drag.is_some() {
             log::info!("Space drag interrupted by fix floor");
@@ -314,7 +320,9 @@ impl PlayspaceMover {
         set_working_copy(&self.universe, chaperone_mgr, &new_mat);
         chaperone_mgr.commit_working_copy(EChaperoneConfigFile::EChaperoneConfigFile_Live);
 
-        playspace_common::shift_world(overlays, anchor, &before, &new_mat);
+        if !app.session.config.space_drag_affects_world {
+            playspace_common::shift_world(overlays, anchor, &before, &new_mat);
+        }
     }
 
     pub fn playspace_changed(

--- a/wayvr/src/backend/openxr/playspace.rs
+++ b/wayvr/src/backend/openxr/playspace.rs
@@ -114,7 +114,11 @@ impl PlayspaceMover {
 
             space_transform.translation = offset;
 
+            let before_pose = data.pose;
             data.pose *= space_transform;
+            if !app.session.config.space_drag_affects_world {
+                playspace_common::shift_world(overlays, &mut app.anchor, &before_pose, &data.pose);
+            }
             data.hand_pose = new_hand;
 
             apply_offset(data.pose, &mut monado.ipc);
@@ -228,7 +232,9 @@ impl PlayspaceMover {
             let after_pose = Affine3A::from_translation(res.playspace_pos.into());
             apply_offset(after_pose, &mut monado.ipc);
 
-            playspace_common::shift_world(overlays, &mut app.anchor, &before_pose, &after_pose);
+            if !app.session.config.space_drag_affects_world {
+                playspace_common::shift_world(overlays, &mut app.anchor, &before_pose, &after_pose);
+            }
         }
     }
 
@@ -300,9 +306,11 @@ impl PlayspaceMover {
 
         self.gravity.reset();
 
-        let after =
-            Affine3A::from_rotation_translation(pose.orientation.into(), pose.position.into());
-        playspace_common::shift_world(overlays, anchor, &before, &after);
+        if !app.session.config.space_drag_affects_world {
+            let after =
+                Affine3A::from_rotation_translation(pose.orientation.into(), pose.position.into());
+            playspace_common::shift_world(overlays, anchor, &before, &after);
+        }
     }
 
     pub fn reset_offset(
@@ -391,7 +399,10 @@ impl PlayspaceMover {
 
         let after =
             Affine3A::from_rotation_translation(pose.orientation.into(), pose.position.into());
-        playspace_common::shift_world(overlays, anchor, &before, &after);
+
+        if !app.session.config.space_drag_affects_world {
+            playspace_common::shift_world(overlays, anchor, &before, &after);
+        }
     }
 
     pub fn save_center(&mut self, monado: &mut Monado) {

--- a/wayvr/src/backend/openxr/playspace.rs
+++ b/wayvr/src/backend/openxr/playspace.rs
@@ -338,8 +338,10 @@ impl PlayspaceMover {
         let offset = self.playspace_state.openxr_space_center;
         apply_offset(offset, &mut monado.ipc);
 
-        let after = offset;
-        playspace_common::shift_world(overlays, &mut app.anchor, &before, &after);
+        if !app.session.config.space_drag_affects_world {
+            let after = offset;
+            playspace_common::shift_world(overlays, &mut app.anchor, &before, &after);
+        }
     }
 
     pub fn fix_floor(


### PR DESCRIPTION
Resolves #601 

Makes `space-reset` follow the `space_drag_affects_world` setting. ("Space Drag Moves Overlays" in UI)

OpenXR works, OpenVR untested.
